### PR TITLE
Replicated config

### DIFF
--- a/src/scala/ly/stealth/mesos/kafka/Config.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Config.scala
@@ -24,8 +24,8 @@ object Config {
   var debug: Boolean = false
   var mesosUser: String = null
 
-  var cMasterUrl: String = null
-  var cZkUrl: String = null
+  var mesosMaster: String = null
+  var kafkaZkConnect: String = null
 
   var masterHost: String =  null
   var masterPort: Int = 5050
@@ -36,8 +36,8 @@ object Config {
 
   var failoverTimeout: Int = 60
 
-  def masterUrl: String = (if (cMasterUrl != null) cMasterUrl else (masterHost + ":" + masterPort))
-  def zkUrl: String = (if (cZkUrl != null) cZkUrl else (masterHost + ":" + zkPort))
+  def masterUrl: String = (if (mesosMaster != null) mesosMaster else (masterHost + ":" + masterPort))
+  def zkUrl: String = (if (kafkaZkConnect != null) kafkaZkConnect else (masterHost + ":" + zkPort))
   def schedulerUrl: String = "http://" + schedulerHost + ":" + schedulerPort
 
   load()
@@ -56,8 +56,8 @@ object Config {
     debug = java.lang.Boolean.valueOf(props.getProperty("debug"))
     mesosUser = props.getProperty("mesos.user")
 
-    cMasterUrl = props.getProperty("master.url")
-    cZkUrl = props.getProperty("zk.url")
+    mesosMaster = props.getProperty("mesos.master")
+    kafkaZkConnect = props.getProperty("kafka.zk.connect")
 
     masterHost = props.getProperty("master.host")
     if (props.getProperty("master.port") != null)

--- a/src/scala/ly/stealth/mesos/kafka/Config.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Config.scala
@@ -24,17 +24,20 @@ object Config {
   var debug: Boolean = false
   var mesosUser: String = null
 
+  var cMasterUrl: String = null
+  var cZkUrl: String = null
+
   var masterHost: String =  null
   var masterPort: Int = 5050
   var zkPort: Int = 2181
-  
+
   var schedulerHost: String = null
   var schedulerPort: Int = 7000
 
   var failoverTimeout: Int = 60
 
-  def masterUrl: String = masterHost + ":" + masterPort
-  def zkUrl: String = masterHost + ":" + zkPort
+  def masterUrl: String = (if (cMasterUrl != null) cMasterUrl else (masterHost + ":" + masterPort))
+  def zkUrl: String = (if (cZkUrl != null) cZkUrl else (masterHost + ":" + zkPort))
   def schedulerUrl: String = "http://" + schedulerHost + ":" + schedulerPort
 
   load()
@@ -46,21 +49,23 @@ object Config {
 
     val props: Properties = new Properties()
     val stream: FileInputStream = new FileInputStream(file)
-    
+
     props.load(stream)
     stream.close()
-    
+
     debug = java.lang.Boolean.valueOf(props.getProperty("debug"))
     mesosUser = props.getProperty("mesos.user")
+
+    cMasterUrl = props.getProperty("master.url")
+    cZkUrl = props.getProperty("zk.url")
 
     masterHost = props.getProperty("master.host")
     masterPort = Integer.parseInt(props.getProperty("master.port"))
     zkPort = Integer.parseInt(props.getProperty("master.zk.port"))
-    
+
     schedulerHost = props.getProperty("scheduler.host")
     schedulerPort = Integer.parseInt(props.getProperty("scheduler.port"))
-    
+
     failoverTimeout = Integer.parseInt(props.getProperty("failoverTimeout"))
   }
 }
-

--- a/src/scala/ly/stealth/mesos/kafka/Config.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Config.scala
@@ -60,8 +60,11 @@ object Config {
     cZkUrl = props.getProperty("zk.url")
 
     masterHost = props.getProperty("master.host")
-    masterPort = Integer.parseInt(props.getProperty("master.port"))
-    zkPort = Integer.parseInt(props.getProperty("master.zk.port"))
+    if (props.getProperty("master.port") != null)
+      masterPort = Integer.parseInt(props.getProperty("master.port"))
+
+    if (props.getProperty("master.zk.port") != null)
+      zkPort = Integer.parseInt(props.getProperty("master.zk.port"))
 
     schedulerHost = props.getProperty("scheduler.host")
     schedulerPort = Integer.parseInt(props.getProperty("scheduler.port"))


### PR DESCRIPTION
i want to run kafka on a mesos cluster with master failover : this wasn't possible

this PR permits the mesos-master connection string and the kafka zk connection to be specified explicitly in the config e.g. 

```
mesos.master=zk://192.168.0.245:2181,192.168.0.246:2181,192.168.0.247:2181/mesos
kafka.zk.connect=192.168.0.245:2181,192.168.0.246:2181,192.168.0.247:2181
```

which permits he scheduler to run on a mesos cluster with master failover under marathon

there's still a problem of how to figure out the IP address of the scheduler, but i can do that manually or from the marathon API if i need to automate
