### PR TITLE
Remove user specified framework Id and persist framework id

### DIFF
--- a/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
@@ -87,6 +87,8 @@ object Scheduler extends org.apache.mesos.Scheduler {
 
   def registered(driver: SchedulerDriver, id: FrameworkID, master: MasterInfo): Unit = {
     logger.info("[registered] framework:" + Str.id(id.getValue) + " master:" + Str.master(master))
+    cluster.frameworkId = Some(id)
+    cluster.save()
     this.driver = driver
     reconcileTasks()
   }
@@ -284,7 +286,7 @@ object Scheduler extends org.apache.mesos.Scheduler {
 
     val frameworkBuilder = FrameworkInfo.newBuilder()
     frameworkBuilder.setUser(Config.mesosUser)
-    frameworkBuilder.setId(FrameworkID.newBuilder().setValue(Config.frameworkId))
+    cluster.frameworkId.map(fwId => frameworkBuilder.setId(fwId))
     frameworkBuilder.setName("Kafka Mesos")
     frameworkBuilder.setFailoverTimeout(Config.failoverTimeout)
     frameworkBuilder.setCheckpoint(true)


### PR DESCRIPTION
Framework Ids are usually generated by the master and assigned back to the framework on register request. Most frameworks store the framework Id and reuse it on relaunch if they want to re-register and reconcile all the running tasks.

I don't think it makes much sense to let the user specify a framework Id, as the user shouldn't care what the framework Id as long as it can relaunch a failed framework and get back running. We want to also let the framework manage this as if we do hope to terminate the framework and never reconcile its tasks, and we shut it down via the master REST shutdown call, the framework with the same id will never be able to launch. 
