### PR TITLE
static_port

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ broker:
   id: 0
   active: false
   state: stopped
-  resources: cpus:1.00, mem:2048, heap:1024
+  resources: cpus:1.00, mem:2048, heap:1024, port:auto
   failover: delay:10s, max-delay:60s
 ```
 
@@ -143,7 +143,7 @@ cluster:
     id: 0
     active: false
     state: stopped
-    resources: cpus:1.00, mem:2048, heap:1024
+    resources: cpus:1.00, mem:2048, heap:1024, port:auto
     failover: delay:10s, max-delay:60s
 ```
 Now lets start the broker.
@@ -164,7 +164,7 @@ cluster:
     id: 0
     active: true
     state: running
-    resources: cpus:1.00, mem:2048, heap:1024
+    resources: cpus:1.00, mem:2048, heap:1024, port:auto
     failover: delay:10s, max-delay:60s
     task:
       id: broker-0-d2d94520-2f3e-4779-b276-771b4843043c
@@ -204,7 +204,7 @@ broker:
   id: 0
   active: false
   state: stopped
-  resources: cpus:1.00, mem:2048, heap:1024
+  resources: cpus:1.00, mem:2048, heap:1024, port:auto
   options: log.dirs=/mnt/array1/broker0
   failover: delay:10s, max-delay:60s
 
@@ -223,19 +223,19 @@ brokers:
   id: 0
   active: false
   state: stopped
-  resources: cpus:1.00, mem:2048, heap:1024
+  resources: cpus:1.00, mem:2048, heap:1024, port:auto
   failover: delay:10s, max-delay:60s
 
   id: 1
   active: false
   state: stopped
-  resources: cpus:1.00, mem:2048, heap:1024
+  resources: cpus:1.00, mem:2048, heap:1024, port:auto
   failover: delay:10s, max-delay:60s
 
   id: 2
   active: false
   state: stopped
-  resources: cpus:1.00, mem:2048, heap:1024
+  resources: cpus:1.00, mem:2048, heap:1024, port:auto
   failover: delay:10s, max-delay:60s
 
 #./kafka-mesos.sh start 0
@@ -292,6 +292,7 @@ Option                Description
 --options             kafka options or file. Examples:
                        log.dirs=/tmp/kafka/$id,num.io.threads=16
                        file:server.properties
+--port                port or range (31092, 31090..31100). Default - auto
 
 Generic Options
 Option  Description
@@ -336,6 +337,7 @@ Option                Description
 --options             kafka options or file. Examples:
                        log.dirs=/tmp/kafka/$id,num.io.threads=16
                        file:server.properties
+--port                port or range (31092, 31090..31100). Default - auto
 
 Generic Options
 Option  Description

--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -24,7 +24,7 @@ import scala.collection
 import org.apache.mesos.Protos.{Resource, Offer}
 import java.util.{TimeZone, Collections, Date, UUID}
 import ly.stealth.mesos.kafka.Broker.Failover
-import Util.{Period, Str}
+import Util.{Period, Range, Str}
 import java.text.SimpleDateFormat
 
 class Broker(_id: String = "0") {
@@ -34,6 +34,7 @@ class Broker(_id: String = "0") {
   var cpus: Double = 1
   var mem: Long = 2048
   var heap: Long = 1024
+  var port: Range = null
 
   var constraints: util.Map[String, Constraint] = new util.LinkedHashMap()
   var options: util.Map[String, String] = new util.LinkedHashMap()
@@ -130,6 +131,7 @@ class Broker(_id: String = "0") {
     cpus = node("cpus").asInstanceOf[Number].doubleValue()
     mem = node("mem").asInstanceOf[Number].longValue()
     heap = node("heap").asInstanceOf[Number].longValue()
+    if (node.contains("port")) port = new Range(node("port").asInstanceOf[String])
 
     if (node.contains("constraints")) constraints = Util.parseMap(node("constraints").asInstanceOf[String])
                                                     .mapValues(new Constraint(_)).view.force
@@ -151,6 +153,7 @@ class Broker(_id: String = "0") {
     obj("cpus") = cpus
     obj("mem") = mem
     obj("heap") = heap
+    if (port != null) obj("port") = "" + port
 
     if (!constraints.isEmpty) obj("constraints") = Util.formatMap(constraints)
     if (!options.isEmpty) obj("options") = Util.formatMap(options)

--- a/src/scala/ly/stealth/mesos/kafka/Cli.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cli.scala
@@ -260,6 +260,7 @@ object Cli {
     parser.accepts("cpus", "cpu amount (0.5, 1, 2)").withRequiredArg().ofType(classOf[java.lang.Double])
     parser.accepts("mem", "mem amount in Mb").withRequiredArg().ofType(classOf[java.lang.Long])
     parser.accepts("heap", "heap amount in Mb").withRequiredArg().ofType(classOf[java.lang.Long])
+    parser.accepts("port", "port or range (9092, 9000..9100). Default - any").withRequiredArg().ofType(classOf[java.lang.String])
 
     parser.accepts("options", "kafka options or file. Examples:\n log.dirs=/tmp/kafka/$id,num.io.threads=16\n file:server.properties").withRequiredArg()
     parser.accepts("constraints", "constraints (hostname=like:master,rack=like:1.*). See below.").withRequiredArg()
@@ -298,6 +299,7 @@ object Cli {
     val cpus = options.valueOf("cpus").asInstanceOf[java.lang.Double]
     val mem = options.valueOf("mem").asInstanceOf[java.lang.Long]
     val heap = options.valueOf("heap").asInstanceOf[java.lang.Long]
+    val port = options.valueOf("port").asInstanceOf[String]
 
     val options_ = options.valueOf("options").asInstanceOf[String]
     val constraints = options.valueOf("constraints").asInstanceOf[String]
@@ -312,6 +314,7 @@ object Cli {
     if (cpus != null) params.put("cpus", "" + cpus)
     if (mem != null) params.put("mem", "" + mem)
     if (heap != null) params.put("heap", "" + heap)
+    if (port != null) params.put("port", port)
 
     if (options_ != null) params.put("options", optionsOrFile(options_))
     if (constraints != null) params.put("constraints", constraints)
@@ -535,7 +538,7 @@ object Cli {
     printLine("id: " + broker.id, indent)
     printLine("active: " + broker.active, indent)
     printLine("state: " + broker.state(), indent)
-    printLine("resources: " + "cpus:" + "%.2f".format(broker.cpus) + ", mem:" + broker.mem + ", heap:" + broker.heap, indent)
+    printLine("resources: " + "cpus:" + "%.2f".format(broker.cpus) + ", mem:" + broker.mem + ", heap:" + broker.heap + ", port:" + (if (broker.port != null) broker.port else "any"), indent)
 
     if (!broker.constraints.isEmpty) printLine("constraints: " + Util.formatMap(broker.constraints), indent)
     if (!broker.options.isEmpty) printLine("options: " + Util.formatMap(broker.options), indent)

--- a/src/scala/ly/stealth/mesos/kafka/Cli.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cli.scala
@@ -260,7 +260,7 @@ object Cli {
     parser.accepts("cpus", "cpu amount (0.5, 1, 2)").withRequiredArg().ofType(classOf[java.lang.Double])
     parser.accepts("mem", "mem amount in Mb").withRequiredArg().ofType(classOf[java.lang.Long])
     parser.accepts("heap", "heap amount in Mb").withRequiredArg().ofType(classOf[java.lang.Long])
-    parser.accepts("port", "port or range (9092, 9000..9100). Default - auto").withRequiredArg().ofType(classOf[java.lang.String])
+    parser.accepts("port", "port or range (31092, 31090..31100). Default - auto").withRequiredArg().ofType(classOf[java.lang.String])
 
     parser.accepts("options", "kafka options or file. Examples:\n log.dirs=/tmp/kafka/$id,num.io.threads=16\n file:server.properties").withRequiredArg()
     parser.accepts("constraints", "constraints (hostname=like:master,rack=like:1.*). See below.").withRequiredArg()

--- a/src/scala/ly/stealth/mesos/kafka/Cli.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cli.scala
@@ -260,7 +260,7 @@ object Cli {
     parser.accepts("cpus", "cpu amount (0.5, 1, 2)").withRequiredArg().ofType(classOf[java.lang.Double])
     parser.accepts("mem", "mem amount in Mb").withRequiredArg().ofType(classOf[java.lang.Long])
     parser.accepts("heap", "heap amount in Mb").withRequiredArg().ofType(classOf[java.lang.Long])
-    parser.accepts("port", "port or range (9092, 9000..9100). Default - any").withRequiredArg().ofType(classOf[java.lang.String])
+    parser.accepts("port", "port or range (9092, 9000..9100). Default - auto").withRequiredArg().ofType(classOf[java.lang.String])
 
     parser.accepts("options", "kafka options or file. Examples:\n log.dirs=/tmp/kafka/$id,num.io.threads=16\n file:server.properties").withRequiredArg()
     parser.accepts("constraints", "constraints (hostname=like:master,rack=like:1.*). See below.").withRequiredArg()
@@ -538,7 +538,7 @@ object Cli {
     printLine("id: " + broker.id, indent)
     printLine("active: " + broker.active, indent)
     printLine("state: " + broker.state(), indent)
-    printLine("resources: " + "cpus:" + "%.2f".format(broker.cpus) + ", mem:" + broker.mem + ", heap:" + broker.heap + ", port:" + (if (broker.port != null) broker.port else "any"), indent)
+    printLine("resources: " + "cpus:" + "%.2f".format(broker.cpus) + ", mem:" + broker.mem + ", heap:" + broker.heap + ", port:" + (if (broker.port != null) broker.port else "auto"), indent)
 
     if (!broker.constraints.isEmpty) printLine("constraints: " + Util.formatMap(broker.constraints), indent)
     if (!broker.options.isEmpty) printLine("options: " + Util.formatMap(broker.options), indent)

--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -27,7 +27,7 @@ import java.util
 import scala.collection.JavaConversions._
 import scala.util.parsing.json.{JSONArray, JSONObject}
 import scala.collection.mutable.ListBuffer
-import ly.stealth.mesos.kafka.Util.Period
+import ly.stealth.mesos.kafka.Util.{Period, Range}
 import ly.stealth.mesos.kafka.Broker.State
 
 object HttpServer {
@@ -155,6 +155,11 @@ object HttpServer {
         try { heap = java.lang.Long.valueOf(request.getParameter("heap")) }
         catch { case e: NumberFormatException => errors.add("Invalid heap") }
 
+      val port: String = request.getParameter("port")
+      if (port != null && port != "")
+        try { new Range(request.getParameter("port")) }
+        catch { case e: IllegalArgumentException => errors.add("Invalid port") }
+
 
       var options: util.Map[String, String] = null
       if (request.getParameter("options") != null)
@@ -210,6 +215,7 @@ object HttpServer {
         if (cpus != null) broker.cpus = cpus
         if (mem != null) broker.mem = mem
         if (heap != null) broker.heap = heap
+        if (port != null) broker.port = if (port != "") new Range(port) else null
 
         if (options != null) broker.options = options
         if (constraints != null) broker.constraints = constraints

--- a/src/scala/ly/stealth/mesos/kafka/Util.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Util.scala
@@ -185,6 +185,39 @@ object Util {
     override def toString: String = _value + _unit
   }
 
+  class Range(s: String) {
+    private var _start: Int = -1
+    private var _end: Int = -1
+
+    parse()
+    private def parse() {
+      val idx = s.indexOf("..")
+
+      if (idx == -1) {
+        _start = Integer.parseInt(s)
+        _end = _start
+        return
+      }
+
+      _start = Integer.parseInt(s.substring(0, idx))
+      _end = Integer.parseInt(s.substring(idx + 2))
+      if (_start > _end) throw new IllegalArgumentException("start > end")
+    }
+
+    def start: Int = _start
+    def end : Int = _end
+
+    override def equals(obj: scala.Any): Boolean = {
+      if (!obj.isInstanceOf[Range]) return false
+      val range = obj.asInstanceOf[Range]
+      start == range.start && end == range.end
+    }
+
+    override def hashCode(): Int = 31 * start + end
+
+    override def toString: String = if (start == end) "" + start else start + ".." + end
+  }
+
   object Str {
     def dateTime(date: Date): String = {
       new SimpleDateFormat("yyyy-MM-dd HH:mm:ssX").format(date)

--- a/src/scala/ly/stealth/mesos/kafka/Util.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Util.scala
@@ -189,6 +189,9 @@ object Util {
     private var _start: Int = -1
     private var _end: Int = -1
 
+    def this(start: Int, end: Int) = this(start + ".." + end)
+    def this(start: Int) = this("" + start)
+
     parse()
     private def parse() {
       val idx = s.indexOf("..")
@@ -206,6 +209,24 @@ object Util {
 
     def start: Int = _start
     def end : Int = _end
+
+    def overlap(r: Range): Range = {
+      var x: Range = this
+      var y: Range = r
+      if (x.start > y.start) {
+        val t = x
+        x = y
+        y = t
+      }
+      assert(x.start <= y.start)
+      
+      if (y.start > x.end) return null
+      assert(y.start <= x.end)
+      
+      val start = y.start
+      val end = Math.min(x.end, y.end)
+      new Range(start, end)
+    }
 
     override def equals(obj: scala.Any): Boolean = {
       if (!obj.isInstanceOf[Range]) return false

--- a/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
@@ -60,6 +60,35 @@ class BrokerTest extends MesosTestCase {
     assertNull(broker.matches(offer(mem = 100)))
     assertEquals("mem 99 < 100", broker.matches(offer(mem = 99)))
     broker.mem = 0
+
+    // port
+    assertNull(broker.matches(offer(ports = "100")))
+    assertEquals("no suitable port", broker.matches(offer(ports = "")))
+  }
+
+  @Test
+  def getSuitablePort {
+    // no port restrictions
+    assertEquals(-1, broker.getSuitablePort(offer(ports = "")))
+    assertEquals(100, broker.getSuitablePort(offer(ports = "100..100")))
+    assertEquals(100, broker.getSuitablePort(offer(ports = "100..200")))
+
+    // single port restriction
+    broker.port = new Util.Range(92)
+    assertEquals(-1, broker.getSuitablePort(offer(ports = "0..91")))
+    assertEquals(-1, broker.getSuitablePort(offer(ports = "93..100")))
+    assertEquals(92, broker.getSuitablePort(offer(ports = "90..100")))
+
+    // port range restriction
+    broker.port = new Util.Range("92..100")
+    assertEquals(-1, broker.getSuitablePort(offer(ports = "0..91")))
+    assertEquals(-1, broker.getSuitablePort(offer(ports = "101..200")))
+    assertEquals(92, broker.getSuitablePort(offer(ports = "0..100")))
+    assertEquals(92, broker.getSuitablePort(offer(ports = "0..92")))
+
+    assertEquals(100, broker.getSuitablePort(offer(ports = "100..200")))
+    assertEquals(95, broker.getSuitablePort(offer(ports = "0..90,95..96,101..200")))
+    assertEquals(96, broker.getSuitablePort(offer(ports = "0..90,96,101..200")))
   }
 
   @Test

--- a/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
@@ -200,6 +200,7 @@ class BrokerTest extends MesosTestCase {
     broker.cpus = 0.5
     broker.mem = 128
     broker.heap = 128
+    broker.port = new Util.Range("0..100")
 
     broker.constraints = parseMap("a=like:1").mapValues(new Constraint(_))
     broker.options = parseMap("a=1")
@@ -333,6 +334,7 @@ object BrokerTest {
     assertEquals(expected.cpus, actual.cpus, 0.001)
     assertEquals(expected.mem, actual.mem)
     assertEquals(expected.heap, actual.heap)
+    assertEquals(expected.port, actual.port)
 
     assertEquals(expected.constraints, actual.constraints)
     assertEquals(expected.options, actual.options)

--- a/src/test/ly/stealth/mesos/kafka/SchedulerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/SchedulerTest.scala
@@ -46,9 +46,9 @@ class SchedulerTest extends MesosTestCase {
     broker.cpus = 0.5
     broker.mem = 256
 
-    val offer = this.offer(slaveId = "slave", hostname = "host", ports = Pair(1000, 1000))
+    val offer = this.offer(slaveId = "slave", hostname = "host")
 
-    val task = Scheduler.newTask(broker, offer)
+    val task = Scheduler.newTask(broker, offer, 1000)
     assertEquals("slave", task.getSlaveId.getValue)
     assertNotNull(task.getExecutor)
 
@@ -87,7 +87,7 @@ class SchedulerTest extends MesosTestCase {
   @Test
   def syncBrokers {
     val broker = Scheduler.cluster.addBroker(new Broker())
-    val offer = this.offer(cpus = broker.cpus, mem = broker.mem, ports = Pair(100, 100))
+    val offer = this.offer(cpus = broker.cpus, mem = broker.mem)
 
     // broker !active
     Scheduler.syncBrokers(util.Arrays.asList(offer))
@@ -116,13 +116,13 @@ class SchedulerTest extends MesosTestCase {
     assertEquals("reconciling", Scheduler.acceptOffer(null))
 
     broker.task = null
-    assertEquals(s"broker ${broker.id}: cpus 0.4 < ${broker.cpus}", Scheduler.acceptOffer(offer(cpus = 0.4, mem = broker.mem, ports = Pair(100, 100))))
-    assertEquals(s"broker ${broker.id}: mem 99 < ${broker.mem}", Scheduler.acceptOffer(offer(cpus = broker.cpus, mem = 99, ports = Pair(100, 100))))
+    assertEquals(s"broker ${broker.id}: cpus 0.4 < ${broker.cpus}", Scheduler.acceptOffer(offer(cpus = 0.4, mem = broker.mem)))
+    assertEquals(s"broker ${broker.id}: mem 99 < ${broker.mem}", Scheduler.acceptOffer(offer(cpus = broker.cpus, mem = 99)))
 
-    assertNull(Scheduler.acceptOffer(offer(cpus = broker.cpus, mem = broker.mem, ports = Pair(100, 100))))
+    assertNull(Scheduler.acceptOffer(offer(cpus = broker.cpus, mem = broker.mem)))
     assertEquals(1, schedulerDriver.launchedTasks.size())
 
-    assertEquals("", Scheduler.acceptOffer(offer(cpus = broker.cpus, mem = broker.mem, ports = Pair(100, 100))))
+    assertEquals("", Scheduler.acceptOffer(offer(cpus = broker.cpus, mem = broker.mem)))
   }
 
   @Test
@@ -185,7 +185,7 @@ class SchedulerTest extends MesosTestCase {
   @Test
   def launchTask {
     val broker = Scheduler.cluster.addBroker(new Broker("100"))
-    val offer = this.offer(cpus = broker.cpus, mem = broker.mem, ports = Pair(1000, 1000), attributes = "a=1,b=2")
+    val offer = this.offer(cpus = broker.cpus, mem = broker.mem, attributes = "a=1,b=2")
 
     Scheduler.launchTask(broker, offer)
     assertEquals(1, schedulerDriver.launchedTasks.size())
@@ -241,15 +241,5 @@ class SchedulerTest extends MesosTestCase {
     assertArrayEquals(Array[AnyRef]("host0", "host1"), Scheduler.otherTasksAttributes("hostname").asInstanceOf[Array[AnyRef]])
     assertArrayEquals(Array[AnyRef]("1"), Scheduler.otherTasksAttributes("a").asInstanceOf[Array[AnyRef]])
     assertArrayEquals(Array[AnyRef]("2", "3"), Scheduler.otherTasksAttributes("b").asInstanceOf[Array[AnyRef]])
-  }
-
-  @Test
-  def findBrokerPort {
-    assertEquals(100, Scheduler.findBrokerPort(offer(ports = Pair(100, 200))))
-    assertEquals(100, Scheduler.findBrokerPort(offer(ports = Pair(100, 100))))
-
-    // no ports
-    try { Scheduler.findBrokerPort(offer()); fail() }
-    catch { case e: IllegalArgumentException => }
   }
 }

--- a/src/test/ly/stealth/mesos/kafka/UtilTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/UtilTest.scala
@@ -201,6 +201,8 @@ class UtilTest {
   def Range_init {
     new Range("30")
     new Range("30..31")
+    new Range(30)
+    new Range(30, 31)
 
     // empty
     try { new Range(""); fail() }
@@ -228,6 +230,28 @@ class UtilTest {
     assertEquals(0, new Range("0").start)
     assertEquals(0, new Range("0..10").start)
     assertEquals(10, new Range("0..10").end)
+  }
+
+  @Test
+  def overlap {
+    // no overlap
+    assertNull(new Range(0, 10).overlap(new Range(20, 30)))
+    assertNull(new Range(20, 30).overlap(new Range(0, 10)))
+    assertNull(new Range(0).overlap(new Range(1)))
+
+    // partial
+    assertEquals(new Range(5, 10), new Range(0, 10).overlap(new Range(5, 15)))
+    assertEquals(new Range(5, 10), new Range(5, 15).overlap(new Range(0, 10)))
+
+    // includes
+    assertEquals(new Range(2, 3), new Range(0, 10).overlap(new Range(2, 3)))
+    assertEquals(new Range(2, 3), new Range(2, 3).overlap(new Range(0, 10)))
+    assertEquals(new Range(5), new Range(0, 10).overlap(new Range(5)))
+
+    // last point
+    assertEquals(new Range(0), new Range(0, 10).overlap(new Range(0)))
+    assertEquals(new Range(10), new Range(0, 10).overlap(new Range(10)))
+    assertEquals(new Range(0), new Range(0).overlap(new Range(0)))
   }
 
   @Test

--- a/src/test/ly/stealth/mesos/kafka/UtilTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/UtilTest.scala
@@ -20,6 +20,7 @@ package ly.stealth.mesos.kafka
 import org.junit.Test
 import org.junit.Assert._
 import ly.stealth.mesos.kafka.Util.Period
+import ly.stealth.mesos.kafka.Util.Range
 import java.io.{ByteArrayOutputStream, ByteArrayInputStream}
 import java.util
 
@@ -193,5 +194,46 @@ class UtilTest {
   def Period_toString {
     assertEquals("10ms", "" + new Period("10ms"))
     assertEquals("5h", "" + new Period("5h"))
+  }
+
+  // Range
+  @Test
+  def Range_init {
+    new Range("30")
+    new Range("30..31")
+
+    // empty
+    try { new Range(""); fail() }
+    catch { case e: IllegalArgumentException => }
+
+    // non int
+    try { new Range("abc"); fail() }
+    catch { case e: IllegalArgumentException => }
+
+    // non int first
+    try { new Range("abc..30"); fail() }
+    catch { case e: IllegalArgumentException => }
+
+    // non int second
+    try { new Range("30..abc"); fail() }
+    catch { case e: IllegalArgumentException => }
+
+    // inverted range
+    try { new Range("10..0"); fail() }
+    catch { case e: IllegalArgumentException => }
+  }
+
+  @Test
+  def Range_start_end {
+    assertEquals(0, new Range("0").start)
+    assertEquals(0, new Range("0..10").start)
+    assertEquals(10, new Range("0..10").end)
+  }
+
+  @Test
+  def Range_toString {
+    assertEquals("0", "" + new Range("0"))
+    assertEquals("0..10", "" + new Range("0..10"))
+    assertEquals("0", "" + new Range("0..0"))
   }
 }


### PR DESCRIPTION
Hey Joe.

This PR would allow to restrict broker ports to a single port or a range.
Examples: add 0 --ports=31092, update 0 --ports=31090..31100

Backward compatibility is preserved, cause by default port is auto-assigned as before.
Please review, evaluate and merge.
