### PR TITLE
fixed acceptors thread pool size. jetty 9 uses acceptors threads == c…

### DIFF
--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -41,7 +41,7 @@ object HttpServer {
     if (server != null) throw new IllegalStateException("started")
     if (resolveDeps) this.resolveDeps
 
-    val threadPool = new QueuedThreadPool(16)
+    val threadPool = new QueuedThreadPool(Runtime.getRuntime.availableProcessors() * 8)
     threadPool.setName("Jetty")
 
     server = new Server(threadPool)

--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -41,7 +41,7 @@ object HttpServer {
     if (server != null) throw new IllegalStateException("started")
     if (resolveDeps) this.resolveDeps
 
-    val threadPool = new QueuedThreadPool(Runtime.getRuntime.availableProcessors() * 8)
+    val threadPool = new QueuedThreadPool(Runtime.getRuntime.availableProcessors() * 16)
     threadPool.setName("Jetty")
 
     server = new Server(threadPool)


### PR DESCRIPTION
…ore numbers, so this should be dynamic
