### PR TITLE
broker_bind_address

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Usage: add <id-expr> [options]
 
 Option                Description
 ------                -----------
+--bind-address        broker bind address (broker0, 192.168.50.*, if:eth1). Default - auto
 --constraints         constraints (hostname=like:master,rack=like:1.*). See below.
 --cpus <Double>       cpu amount (0.5, 1, 2)
 --failover-delay      failover delay (10s, 5m, 3h)
@@ -332,6 +333,7 @@ Usage: update <id-expr> [options]
 
 Option                Description
 ------                -----------
+--bind-address        broker bind address (broker0, 192.168.50.*, if:eth1). Default - auto
 --constraints         constraints (hostname=like:master,rack=like:1.*). See below.
 --cpus <Double>       cpu amount (0.5, 1, 2)
 --failover-delay      failover delay (10s, 5m, 3h)

--- a/kafka-mesos.properties
+++ b/kafka-mesos.properties
@@ -7,7 +7,7 @@ storage=file:kafka-mesos.json
 
 master=zk://master:2181/mesos
 
-zk=master:2181
+zk=master:2181/abc
 
 api=http://192.168.3.1:7000
 

--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -35,7 +35,7 @@ class Broker(_id: String = "0") {
   var mem: Long = 2048
   var heap: Long = 1024
   var port: Range = null
-  var bindAddress: BindAddress = new BindAddress("offer:hostname")
+  var bindAddress: BindAddress = null
 
   var constraints: util.Map[String, Constraint] = new util.LinkedHashMap()
   var options: util.Map[String, String] = new util.LinkedHashMap()
@@ -180,7 +180,7 @@ class Broker(_id: String = "0") {
     obj("mem") = mem
     obj("heap") = heap
     if (port != null) obj("port") = "" + port
-    obj("bindAddress") = "" + bindAddress
+    if (bindAddress != null) obj("bindAddress") = "" + bindAddress
 
     if (!constraints.isEmpty) obj("constraints") = Util.formatMap(constraints)
     if (!options.isEmpty) obj("options") = Util.formatMap(options)

--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -24,7 +24,7 @@ import scala.collection
 import org.apache.mesos.Protos.{Resource, Offer}
 import java.util.{TimeZone, Collections, Date, UUID}
 import ly.stealth.mesos.kafka.Broker.Failover
-import Util.{Period, Range, Str}
+import ly.stealth.mesos.kafka.Util.{BindAddress, Period, Range, Str}
 import java.text.SimpleDateFormat
 
 class Broker(_id: String = "0") {
@@ -35,6 +35,7 @@ class Broker(_id: String = "0") {
   var mem: Long = 2048
   var heap: Long = 1024
   var port: Range = null
+  var bindAddress: BindAddress = new BindAddress("offer:hostname")
 
   var constraints: util.Map[String, Constraint] = new util.LinkedHashMap()
   var options: util.Map[String, String] = new util.LinkedHashMap()
@@ -155,6 +156,7 @@ class Broker(_id: String = "0") {
     mem = node("mem").asInstanceOf[Number].longValue()
     heap = node("heap").asInstanceOf[Number].longValue()
     if (node.contains("port")) port = new Range(node("port").asInstanceOf[String])
+    if (node.contains("bindAddress")) bindAddress = new BindAddress(node("bindAddress").asInstanceOf[String])
 
     if (node.contains("constraints")) constraints = Util.parseMap(node("constraints").asInstanceOf[String])
                                                     .mapValues(new Constraint(_)).view.force
@@ -178,6 +180,7 @@ class Broker(_id: String = "0") {
     obj("mem") = mem
     obj("heap") = heap
     if (port != null) obj("port") = "" + port
+    obj("bindAddress") = "" + bindAddress
 
     if (!constraints.isEmpty) obj("constraints") = Util.formatMap(constraints)
     if (!options.isEmpty) obj("options") = Util.formatMap(options)

--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -48,6 +48,10 @@ class Broker(_id: String = "0") {
     if (defaults != null) result.putAll(defaults)
     
     result.putAll(options)
+
+    if (bindAddress != null)
+      result.put("host.name", bindAddress.resolve())
+
     for ((k, v) <- result)
       result.put(k, v.replace("$id", id))
 

--- a/src/scala/ly/stealth/mesos/kafka/BrokerServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/BrokerServer.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConversions._
 
 abstract class BrokerServer {
   def isStarted: Boolean
-  def start(options: util.Map[String, String] = new util.HashMap(), log4jOptions: util.Map[String, String] = new util.HashMap()): Unit
+  def start(broker: Broker, defaults: util.Map[String, String] = new util.HashMap()): Unit
   def stop(): Unit
   def waitFor(): Unit
 }
@@ -37,11 +37,11 @@ class KafkaServer extends BrokerServer {
 
   def isStarted: Boolean = server != null
 
-  def start(options: util.Map[String, String], log4jOptions: util.Map[String, String] = new util.HashMap()): Unit = {
+  def start(broker: Broker, defaults: util.Map[String, String] = new util.HashMap()): Unit = {
     if (isStarted) throw new IllegalStateException("started")
 
-    BrokerServer.Distro.configureLog4j(log4jOptions)
-    server = BrokerServer.Distro.newServer(options)
+    BrokerServer.Distro.configureLog4j(broker.log4jOptions)
+    server = BrokerServer.Distro.newServer(broker.options(defaults))
 
     logger.info("Starting KafkaServer")
     server.getClass.getMethod("startup").invoke(server)

--- a/src/scala/ly/stealth/mesos/kafka/Cli.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cli.scala
@@ -261,6 +261,7 @@ object Cli {
     parser.accepts("mem", "mem amount in Mb").withRequiredArg().ofType(classOf[java.lang.Long])
     parser.accepts("heap", "heap amount in Mb").withRequiredArg().ofType(classOf[java.lang.Long])
     parser.accepts("port", "port or range (31092, 31090..31100). Default - auto").withRequiredArg().ofType(classOf[java.lang.String])
+    parser.accepts("bind-address", "broker bind address (broker0, 192.168.50.*, if:eth1). Default - auto").withRequiredArg().ofType(classOf[java.lang.String])
 
     parser.accepts("options", "broker options or file. Examples:\n log.dirs=/tmp/kafka/$id,num.io.threads=16\n file:server.properties").withRequiredArg()
     parser.accepts("log4j-options", "log4j options or file. Examples:\n log4j.logger.kafka=DEBUG\\, kafkaAppender\n file:log4j.properties").withRequiredArg()
@@ -301,6 +302,7 @@ object Cli {
     val mem = options.valueOf("mem").asInstanceOf[java.lang.Long]
     val heap = options.valueOf("heap").asInstanceOf[java.lang.Long]
     val port = options.valueOf("port").asInstanceOf[String]
+    val bindAddress = options.valueOf("bind-address").asInstanceOf[String]
 
     val constraints = options.valueOf("constraints").asInstanceOf[String]
     val options_ = options.valueOf("options").asInstanceOf[String]
@@ -317,6 +319,7 @@ object Cli {
     if (mem != null) params.put("mem", "" + mem)
     if (heap != null) params.put("heap", "" + heap)
     if (port != null) params.put("port", port)
+    if (bindAddress != null) params.put("bindAddress", bindAddress)
 
     if (options_ != null) params.put("options", optionsOrFile(options_))
     if (constraints != null) params.put("constraints", constraints)
@@ -543,6 +546,7 @@ object Cli {
     printLine("state: " + broker.state(), indent)
     printLine("resources: " + "cpus:" + "%.2f".format(broker.cpus) + ", mem:" + broker.mem + ", heap:" + broker.heap + ", port:" + (if (broker.port != null) broker.port else "auto"), indent)
 
+    if (broker.bindAddress != null) printLine("bind-address: " + broker.bindAddress, indent)
     if (!broker.constraints.isEmpty) printLine("constraints: " + Util.formatMap(broker.constraints), indent)
     if (!broker.options.isEmpty) printLine("options: " + Util.formatMap(broker.options), indent)
     if (!broker.log4jOptions.isEmpty) printLine("log4j-options: " + Util.formatMap(broker.log4jOptions), indent)

--- a/src/scala/ly/stealth/mesos/kafka/Executor.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Executor.scala
@@ -68,9 +68,11 @@ object Executor extends org.apache.mesos.Executor {
     def runBroker0 {
       try {
         val data: util.Map[String, String] = Util.parseMap(task.getData.toStringUtf8)
-        val options = Util.parseMap(data.get("options"))
-        val log4jOptions = Util.parseMap(data.get("log4jOptions"))
-        server.start(options, log4jOptions)
+        val broker = new Broker()
+        broker.fromJson(Util.parseJson(data.get("broker")))
+
+        val defaults = Util.parseMap(data.get("defaults"))
+        server.start(broker, defaults)
 
         var status = TaskStatus.newBuilder.setTaskId(task.getTaskId).setState(TaskState.TASK_RUNNING).build
         driver.sendStatusUpdate(status)

--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -27,7 +27,7 @@ import java.util
 import scala.collection.JavaConversions._
 import scala.util.parsing.json.{JSONArray, JSONObject}
 import scala.collection.mutable.ListBuffer
-import ly.stealth.mesos.kafka.Util.{Period, Range}
+import ly.stealth.mesos.kafka.Util.{BindAddress, Period, Range}
 import ly.stealth.mesos.kafka.Broker.State
 
 object HttpServer {
@@ -161,6 +161,10 @@ object HttpServer {
         try { new Range(request.getParameter("port")) }
         catch { case e: IllegalArgumentException => errors.add("Invalid port") }
 
+      val bindAddress: String = request.getParameter("bindAddress")
+      if (bindAddress != null)
+        try { new BindAddress(request.getParameter("bindAddress")) }
+        catch { case e: IllegalArgumentException => errors.add("Invalid bindAddress") }
 
       var options: util.Map[String, String] = null
       if (request.getParameter("options") != null)
@@ -221,6 +225,7 @@ object HttpServer {
         if (mem != null) broker.mem = mem
         if (heap != null) broker.heap = heap
         if (port != null) broker.port = if (port != "") new Range(port) else null
+        if (bindAddress != null) broker.bindAddress = if (bindAddress != "") new BindAddress(bindAddress) else null
 
         if (constraints != null) broker.constraints = constraints
         if (options != null) broker.options = options

--- a/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
@@ -70,8 +70,8 @@ object Scheduler extends org.apache.mesos.Scheduler {
       )
 
       val data = new util.HashMap[String, String]()
-      data.put("options", Util.formatMap(broker.options(defaults)))
-      data.put("log4jOptions", Util.formatMap(broker.log4jOptions))
+      data.put("broker", "" + broker.toJson)
+      data.put("defaults", Util.formatMap(defaults))
       ByteString.copyFromUtf8(Util.formatMap(data))
     }
 

--- a/src/scala/ly/stealth/mesos/kafka/Util.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Util.scala
@@ -250,23 +250,20 @@ object Util {
     parse
     def parse {
       val idx = s.indexOf(":")
-      if (idx == -1) throw new IllegalArgumentException(s)
+      if (idx != -1) {
+        _source = s.substring(0, idx)
+        _value = s.substring(idx + 1)
+      } else
+        _value = s
 
-      _source = s.substring(0, idx)
-      _value = s.substring(idx + 1)
-      
-      if (!Array("offer", "address", "interface").contains(_source))
-        throw new IllegalArgumentException(s)
-      
-      if (_source == "offer" && _value != "hostname")
+      if (source != null && source != "if")
         throw new IllegalArgumentException(s)
     }
     
     def resolve(offer: Offer): String = {
       _source match {
-        case "offer" => offer.getHostname
-        case "address" => resolveAddress(_value)
-        case "interface" => resolveInterfaceAddress(_value)
+        case null => resolveAddress(_value)
+        case "if" => resolveInterfaceAddress(_value)
       }
     }
 

--- a/src/scala/ly/stealth/mesos/kafka/Util.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Util.scala
@@ -260,10 +260,11 @@ object Util {
         throw new IllegalArgumentException(s)
     }
     
-    def resolve(offer: Offer): String = {
+    def resolve(): String = {
       _source match {
         case null => resolveAddress(_value)
         case "if" => resolveInterfaceAddress(_value)
+        case _ => throw new IllegalStateException("Failed to resolve " + s)
       }
     }
 
@@ -275,17 +276,19 @@ object Util {
         val address = ni.getInetAddresses.find(_.getHostAddress.startsWith(prefix)).getOrElse(null)
         if (address != null) return address.getHostAddress
       }
-      
-      null
+
+      throw new IllegalStateException("Failed to resolve " + s)
     }
 
     def resolveInterfaceAddress(name: String): String = {
       val ni = NetworkInterface.getNetworkInterfaces.find(_.getName == name).getOrElse(null)
-      if (ni == null) return null
+      if (ni == null) throw new IllegalStateException("Failed to resolve " + s)
 
       val addresses: util.Enumeration[InetAddress] = ni.getInetAddresses
       val address = addresses.find(_.isInstanceOf[Inet4Address]).getOrElse(null)
-      if (address != null) address.getHostAddress else null
+      if (address != null) return address.getHostAddress
+
+      throw new IllegalStateException("Failed to resolve " + s)
     }
 
 

--- a/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
@@ -230,6 +230,7 @@ class BrokerTest extends MesosTestCase {
     broker.mem = 128
     broker.heap = 128
     broker.port = new Util.Range("0..100")
+    broker.bindAddress = new Util.BindAddress("address:192.168.0.1")
 
     broker.constraints = parseMap("a=like:1").mapValues(new Constraint(_))
     broker.options = parseMap("a=1")
@@ -365,6 +366,7 @@ object BrokerTest {
     assertEquals(expected.mem, actual.mem)
     assertEquals(expected.heap, actual.heap)
     assertEquals(expected.port, actual.port)
+    assertEquals(expected.bindAddress, actual.bindAddress)
 
     assertEquals(expected.constraints, actual.constraints)
     assertEquals(expected.options, actual.options)

--- a/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
@@ -19,11 +19,10 @@ package ly.stealth.mesos.kafka
 
 import org.junit.{Before, Test}
 import org.junit.Assert._
-import ly.stealth.mesos.kafka.Util.Period
+import ly.stealth.mesos.kafka.Util.{BindAddress, Period, parseMap}
 import java.util.Date
 import scala.collection.JavaConversions._
 import ly.stealth.mesos.kafka.Broker.{State, Task, Failover}
-import Util.parseMap
 
 class BrokerTest extends MesosTestCase {
   var broker: Broker = null
@@ -45,6 +44,13 @@ class BrokerTest extends MesosTestCase {
     // defaults
     broker.options = parseMap("a=2")
     assertEquals(parseMap("a=2,b=1"), broker.options(parseMap("a=2,b=1")))
+
+    // bind-address
+    broker.options = parseMap("host.name=123")
+    assertEquals(parseMap("host.name=123"), broker.options())
+
+    broker.bindAddress = new BindAddress("127.0.0.1")
+    assertEquals(parseMap("host.name=127.0.0.1"), broker.options())
   }
 
   @Test
@@ -230,7 +236,7 @@ class BrokerTest extends MesosTestCase {
     broker.mem = 128
     broker.heap = 128
     broker.port = new Util.Range("0..100")
-    broker.bindAddress = new Util.BindAddress("address:192.168.0.1")
+    broker.bindAddress = new Util.BindAddress("192.168.0.1")
 
     broker.constraints = parseMap("a=like:1").mapValues(new Constraint(_))
     broker.options = parseMap("a=1")

--- a/src/test/ly/stealth/mesos/kafka/ExecutorTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/ExecutorTest.scala
@@ -56,7 +56,7 @@ class ExecutorTest extends MesosTestCase {
 
   @Test
   def stopExecutor {
-    Executor.server.start()
+    Executor.server.start(null)
     assertTrue(Executor.server.isStarted)
     assertEquals(Status.DRIVER_RUNNING, executorDriver.status)
 
@@ -77,7 +77,7 @@ class ExecutorTest extends MesosTestCase {
 
   @Test(timeout = 5000)
   def killTask {
-    Executor.server.start()
+    Executor.server.start(null)
     Executor.killTask(executorDriver, taskId())
 
     Executor.server.waitFor()
@@ -86,7 +86,7 @@ class ExecutorTest extends MesosTestCase {
 
   @Test
   def shutdown {
-    Executor.server.start()
+    Executor.server.start(null)
     Executor.shutdown(executorDriver)
     assertFalse(Executor.server.isStarted)
   }

--- a/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
+++ b/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
@@ -177,7 +177,7 @@ class MesosTestCase {
     id: String = "" + UUID.randomUUID(),
     name: String = "Task",
     slaveId: String = "" + UUID.randomUUID(),
-    data: String = null
+    data: String = Util.formatMap(Collections.singletonMap("broker", new Broker().toJson))
   ): TaskInfo = {
     val builder = TaskInfo.newBuilder()
     .setName(id)
@@ -329,7 +329,7 @@ class TestBrokerServer extends BrokerServer {
 
   def isStarted: Boolean = started.get()
 
-  def start(options: util.Map[String, String], log4jOptions: util.Map[String, String]): Unit = {
+  def start(broker: Broker, defaults: util.Map[String, String] = new util.HashMap()): Unit = {
     if (failOnStart) throw new RuntimeException("failOnStart")
     started.set(true)
   }

--- a/src/test/ly/stealth/mesos/kafka/SchedulerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/SchedulerTest.scala
@@ -73,21 +73,20 @@ class SchedulerTest extends MesosTestCase {
     assertEquals(1000, range.getBegin)
     assertEquals(1000, range.getEnd)
 
-    // options
+    // data
     val data: util.Map[String, String] = Util.parseMap(task.getData.toStringUtf8)
-    val options = Util.parseMap(data.get("options"))
-    assertEquals(broker.id, options.get("broker.id"))
-    assertEquals("" + 1000, options.get("port"))
-    assertEquals(Config.zk, options.get("zookeeper.connect"))
+    
+    val readBroker: Broker = new Broker()
+    readBroker.fromJson(Util.parseJson(data.get("broker")))
+    BrokerTest.assertBrokerEquals(broker, readBroker)
 
-    assertEquals("kafka-logs", options.get("log.dirs"))
-    assertEquals(offer.getHostname, options.get("host.name"))
+    val defaults = Util.parseMap(data.get("defaults"))
+    assertEquals(broker.id, defaults.get("broker.id"))
+    assertEquals("" + 1000, defaults.get("port"))
+    assertEquals(Config.zk, defaults.get("zookeeper.connect"))
 
-    assertEquals("1", options.get("a"))
-
-    // log4j options
-    val log4jOptions = Util.parseMap(data.get("log4jOptions"))
-    assertEquals(broker.log4jOptions, log4jOptions)
+    assertEquals("kafka-logs", defaults.get("log.dirs"))
+    assertEquals(offer.getHostname, defaults.get("host.name"))
   }
 
   @Test

--- a/src/test/ly/stealth/mesos/kafka/UtilTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/UtilTest.scala
@@ -264,43 +264,24 @@ class UtilTest {
   // BindAddress
   @Test
   def BindAddress_init {
-    new BindAddress("offer:hostname")
-    new BindAddress("address:broker0")
-    new BindAddress("address:192.168.*")
-    new BindAddress("interface:eth1")
+    new BindAddress("broker0")
+    new BindAddress("192.168.*")
+    new BindAddress("if:eth1")
 
     // unknown source
     try { new BindAddress("unknown:value"); fail() }
-    catch { case e: IllegalArgumentException => }
-
-    // no colon
-    try { new BindAddress("offer"); fail() }
-    catch { case e: IllegalArgumentException => }
-
-    // wrong offer attribute
-    try { new BindAddress("offer:ip"); fail() }
     catch { case e: IllegalArgumentException => }
   }
 
   @Test
   def BindAddress_resolve {
-    // offer
-    val offer = Offer.newBuilder()
-      .setId(OfferID.newBuilder().setValue("id").build())
-      .setFrameworkId(FrameworkID.newBuilder().setValue("id").build())
-      .setSlaveId(SlaveID.newBuilder().setValue("id").build())
-      .setHostname("host")
-      .build()
-
-    assertEquals("host", new BindAddress("offer:hostname").resolve(offer))
-
     // address without mask
-    assertEquals("host", new BindAddress("address:host").resolve(null))
+    assertEquals("host", new BindAddress("host").resolve(null))
 
     // address with mask
-    assertEquals("127.0.0.1", new BindAddress("address:127.0.0.*").resolve(null))
+    assertEquals("127.0.0.1", new BindAddress("127.0.0.*").resolve(null))
 
     // interface
-    assertEquals("127.0.0.1", new BindAddress("interface:lo").resolve(null))
+    assertEquals("127.0.0.1", new BindAddress("if:lo").resolve(null))
   }
 }

--- a/src/test/ly/stealth/mesos/kafka/UtilTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/UtilTest.scala
@@ -22,7 +22,6 @@ import org.junit.Assert._
 import ly.stealth.mesos.kafka.Util.{BindAddress, Period, Range}
 import java.io.{ByteArrayOutputStream, ByteArrayInputStream}
 import java.util
-import org.apache.mesos.Protos.{SlaveID, FrameworkID, OfferID, Offer}
 
 class UtilTest {
   @Test
@@ -276,12 +275,16 @@ class UtilTest {
   @Test
   def BindAddress_resolve {
     // address without mask
-    assertEquals("host", new BindAddress("host").resolve(null))
+    assertEquals("host", new BindAddress("host").resolve())
 
     // address with mask
-    assertEquals("127.0.0.1", new BindAddress("127.0.0.*").resolve(null))
+    assertEquals("127.0.0.1", new BindAddress("127.0.0.*").resolve())
 
     // interface
-    assertEquals("127.0.0.1", new BindAddress("if:lo").resolve(null))
+    assertEquals("127.0.0.1", new BindAddress("if:lo").resolve())
+
+    // unresolvable
+    try { new BindAddress("255.255.*").resolve(); fail() }
+    catch { case e: IllegalStateException => }
   }
 }


### PR DESCRIPTION
Hey.

I've added option --bind-address to broker add|update commands.
Format is following: <address>|<address*>|if:<ifname>
Examples: broker0, 192.168.3.5, 192.168.*, if:eth0

Please review and merge.
