### PR TITLE
Add Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM mesosphere/mesos:0.22.1-1.0.ubuntu1404
+
+ADD . /kafka
+
+WORKDIR /kafka
+
+RUN ./gradlew jav
+
+RUN apt-get update && apt-get -y install wget
+
+RUN wget -q https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz
+
+ENV MESOS_NATIVE_JAVA_LIBRARY /usr/local/lib/libmesos.so

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,5 @@ RUN apt-get update && apt-get -y install wget
 RUN wget -q https://archive.apache.org/dist/kafka/0.8.2.1/kafka_2.10-0.8.2.1.tgz
 
 ENV MESOS_NATIVE_JAVA_LIBRARY /usr/local/lib/libmesos.so
+
+ENTRYPOINT ["/kafka/kafka-mesos.sh", "scheduler"]

--- a/kafka-mesos.sh
+++ b/kafka-mesos.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+if [ ! -f ./kafka-mesos.sh ]
+then
+   cd /kafka
+fi
+
 jar='kafka-mesos*.jar'
 
 check_jar() {


### PR DESCRIPTION
The docker directory didn't look like it worked. I added a dockerfile that builds the scheduler and starts the scheduler. You will need to do an ADD to add your own kafka-mesos.properties or supply the full list of command line flags when running the container.

I also needed to change the run script to cd to /kafka if not in the framework directory.

Let me know if you have any questions.
