### PR TITLE
broker_jvm_opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,11 +290,12 @@ Option                Description
 --failover-max-delay  max failover delay. See failoverDelay.
 --failover-max-tries  max failover tries. Default - none
 --heap <Long>         heap amount in Mb
+--jvm-options         jvm options string (-Xms128m -XX:PermSize=48m)
 --log4j-options       log4j options or file. Examples:
                        log4j.logger.kafka=DEBUG\, kafkaAppender
                        file:log4j.properties
 --mem <Long>          mem amount in Mb
---options             broker options or file. Examples:
+--options             options or file. Examples:
                        log.dirs=/tmp/kafka/$id,num.io.threads=16
                        file:server.properties
 --port                port or range (31092, 31090..31100). Default - auto
@@ -338,11 +339,12 @@ Option                Description
 --failover-max-delay  max failover delay. See failoverDelay.
 --failover-max-tries  max failover tries. Default - none
 --heap <Long>         heap amount in Mb
+--jvm-options         jvm options string (-Xms128m -XX:PermSize=48m)
 --log4j-options       log4j options or file. Examples:
                        log4j.logger.kafka=DEBUG\, kafkaAppender
                        file:log4j.properties
 --mem <Long>          mem amount in Mb
---options             broker options or file. Examples:
+--options             options or file. Examples:
                        log.dirs=/tmp/kafka/$id,num.io.threads=16
                        file:server.properties
 --port                port or range (31092, 31090..31100). Default - auto

--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -39,6 +39,7 @@ class Broker(_id: String = "0") {
   var constraints: util.Map[String, Constraint] = new util.LinkedHashMap()
   var options: util.Map[String, String] = new util.LinkedHashMap()
   var log4jOptions: util.Map[String, String] = new util.LinkedHashMap()
+  var jvmOptions: String = null
 
   var failover: Failover = new Failover()
 
@@ -160,6 +161,7 @@ class Broker(_id: String = "0") {
                                                     .mapValues(new Constraint(_)).view.force
     if (node.contains("options")) options = Util.parseMap(node("options").asInstanceOf[String])
     if (node.contains("log4jOptions")) log4jOptions = Util.parseMap(node("log4jOptions").asInstanceOf[String])
+    if (node.contains("jvmOptions")) jvmOptions = node("jvmOptions").asInstanceOf[String]
 
     failover.fromJson(node("failover").asInstanceOf[Map[String, Object]])
 
@@ -182,6 +184,7 @@ class Broker(_id: String = "0") {
     if (!constraints.isEmpty) obj("constraints") = Util.formatMap(constraints)
     if (!options.isEmpty) obj("options") = Util.formatMap(options)
     if (!log4jOptions.isEmpty) obj("log4jOptions") = Util.formatMap(log4jOptions)
+    if (jvmOptions != null) obj("jvmOptions") = jvmOptions
 
     obj("failover") = failover.toJson
     if (task != null) obj("task") = task.toJson

--- a/src/scala/ly/stealth/mesos/kafka/Cli.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cli.scala
@@ -262,8 +262,9 @@ object Cli {
     parser.accepts("heap", "heap amount in Mb").withRequiredArg().ofType(classOf[java.lang.Long])
     parser.accepts("port", "port or range (31092, 31090..31100). Default - auto").withRequiredArg().ofType(classOf[java.lang.String])
 
-    parser.accepts("options", "broker options or file. Examples:\n log.dirs=/tmp/kafka/$id,num.io.threads=16\n file:server.properties").withRequiredArg()
+    parser.accepts("options", "options or file. Examples:\n log.dirs=/tmp/kafka/$id,num.io.threads=16\n file:server.properties").withRequiredArg()
     parser.accepts("log4j-options", "log4j options or file. Examples:\n log4j.logger.kafka=DEBUG\\, kafkaAppender\n file:log4j.properties").withRequiredArg()
+    parser.accepts("jvm-options", "jvm options string (-Xms128m -XX:PermSize=48m)").withRequiredArg()
     parser.accepts("constraints", "constraints (hostname=like:master,rack=like:1.*). See below.").withRequiredArg()
 
     parser.accepts("failover-delay", "failover delay (10s, 5m, 3h)").withRequiredArg().ofType(classOf[String])
@@ -305,6 +306,7 @@ object Cli {
     val constraints = options.valueOf("constraints").asInstanceOf[String]
     val options_ = options.valueOf("options").asInstanceOf[String]
     val log4jOptions = options.valueOf("log4j-options").asInstanceOf[String]
+    val jvmOptions = options.valueOf("jvm-options").asInstanceOf[String]
 
     val failoverDelay = options.valueOf("failover-delay").asInstanceOf[String]
     val failoverMaxDelay = options.valueOf("failover-max-delay").asInstanceOf[String]
@@ -321,6 +323,7 @@ object Cli {
     if (options_ != null) params.put("options", optionsOrFile(options_))
     if (constraints != null) params.put("constraints", constraints)
     if (log4jOptions != null) params.put("log4jOptions", optionsOrFile(log4jOptions))
+    if (jvmOptions != null) params.put("jvmOptions", jvmOptions)
 
     if (failoverDelay != null) params.put("failoverDelay", failoverDelay)
     if (failoverMaxDelay != null) params.put("failoverMaxDelay", failoverMaxDelay)
@@ -546,6 +549,7 @@ object Cli {
     if (!broker.constraints.isEmpty) printLine("constraints: " + Util.formatMap(broker.constraints), indent)
     if (!broker.options.isEmpty) printLine("options: " + Util.formatMap(broker.options), indent)
     if (!broker.log4jOptions.isEmpty) printLine("log4j-options: " + Util.formatMap(broker.log4jOptions), indent)
+    if (broker.jvmOptions != null) printLine("jvm-options: " + broker.jvmOptions, indent)
 
     var failover = "failover:"
     failover += " delay:" + broker.failover.delay

--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -167,15 +167,18 @@ object HttpServer {
         try { options = Util.parseMap(request.getParameter("options"), nullValues = false).filterKeys(Broker.isOptionOverridable).view.force }
         catch { case e: IllegalArgumentException => errors.add("Invalid options: " + e.getMessage) }
 
+      var log4jOptions: util.Map[String, String] = null
+      if (request.getParameter("log4jOptions") != null)
+        try { log4jOptions = Util.parseMap(request.getParameter("log4jOptions")) }
+        catch { case e: IllegalArgumentException => errors.add("Invalid log4jOptions: " + e.getMessage) }
+
+      var jvmOptions: String = request.getParameter("jvmOptions")
+
       var constraints: util.Map[String, Constraint] = null
       if (request.getParameter("constraints") != null)
         try { constraints = Util.parseMap(request.getParameter("constraints"), nullValues = false).mapValues(new Constraint(_)).view.force }
         catch { case e: IllegalArgumentException => errors.add("Invalid constraints: " + e.getMessage) }
 
-      var log4jOptions: util.Map[String, String] = null
-      if (request.getParameter("log4jOptions") != null)
-        try { log4jOptions = Util.parseMap(request.getParameter("log4jOptions")) }
-        catch { case e: IllegalArgumentException => errors.add("Invalid log4jOptions: " + e.getMessage) }
 
       var failoverDelay: Period = null
       if (request.getParameter("failoverDelay") != null)
@@ -225,6 +228,7 @@ object HttpServer {
         if (constraints != null) broker.constraints = constraints
         if (options != null) broker.options = options
         if (log4jOptions != null) broker.log4jOptions = log4jOptions
+        if (jvmOptions != null) broker.jvmOptions = if (jvmOptions != "") jvmOptions else null
 
         if (failoverDelay != null) broker.failover.delay = failoverDelay
         if (failoverMaxDelay != null) broker.failover.maxDelay = failoverMaxDelay

--- a/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
@@ -35,6 +35,7 @@ object Scheduler extends org.apache.mesos.Scheduler {
   private[kafka] def newExecutor(broker: Broker): ExecutorInfo = {
     var cmd = "java -cp " + HttpServer.jar.getName
     cmd += " -Xmx" + broker.heap + "m"
+    if (broker.jvmOptions != null) cmd += " " + broker.jvmOptions
 
     if (Config.debug) cmd += " -Ddebug"
     cmd += " ly.stealth.mesos.kafka.Executor"

--- a/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
@@ -234,6 +234,7 @@ class BrokerTest extends MesosTestCase {
     broker.constraints = parseMap("a=like:1").mapValues(new Constraint(_))
     broker.options = parseMap("a=1")
     broker.log4jOptions = parseMap("b=2")
+    broker.jvmOptions = "-Xms512m"
 
     broker.failover.registerFailure(new Date())
     broker.task = new Task("1", "slave", "executor", "host", 9092)
@@ -369,6 +370,7 @@ object BrokerTest {
     assertEquals(expected.constraints, actual.constraints)
     assertEquals(expected.options, actual.options)
     assertEquals(expected.log4jOptions, actual.log4jOptions)
+    assertEquals(expected.jvmOptions, actual.jvmOptions)
 
     assertFailoverEquals(expected.failover, actual.failover)
     assertTaskEquals(expected.task, actual.task)

--- a/src/test/ly/stealth/mesos/kafka/SchedulerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/SchedulerTest.scala
@@ -29,6 +29,7 @@ class SchedulerTest extends MesosTestCase {
   def newExecutor {
     val broker = new Broker("1")
     broker.heap = 512
+    broker.jvmOptions = "-Xms64m"
 
     val executor = Scheduler.newExecutor(broker)
     val command = executor.getCommand
@@ -36,6 +37,7 @@ class SchedulerTest extends MesosTestCase {
 
     val cmd: String = command.getValue
     assertTrue(cmd, cmd.contains("-Xmx" + broker.heap + "m"))
+    assertTrue(cmd, cmd.contains(broker.jvmOptions))
     assertTrue(cmd, cmd.contains(Executor.getClass.getName.replace("$", "")))
   }
 


### PR DESCRIPTION
Hey,

I've added --jvm-options option to add|update commands.
It accepts jvm options as string parameter.
Example: `./kafka-mesos.sh update 0 --jvm-options="-Xms64m"

Please review&merge.
