### PR TITLE
broker_stickiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ broker:
   state: stopped
   resources: cpus:1.00, mem:2048, heap:1024, port:auto
   options: log.dirs=/mnt/array1/broker0
-  failover: delay:1m, max-delay:10m, sticky-period:10m
+  failover: delay:1m, max-delay:10m
+  stickiness: period:10m, hostname:slave0, expires:2015-07-10 15:51:43+03
 
 # ./kafka-mesos.sh start 0
 Broker 0 started
@@ -226,19 +227,22 @@ brokers:
   active: false
   state: stopped
   resources: cpus:1.00, mem:2048, heap:1024, port:auto
-  failover: delay:1m, max-delay:10m, sticky-period:10m
+  failover: delay:1m, max-delay:10m
+  stickiness: period:10m, hostname:slave0, expires:2015-07-10 15:51:43+03
 
   id: 1
   active: false
   state: stopped
   resources: cpus:1.00, mem:2048, heap:1024, port:auto
-  failover: delay:1m, max-delay:10m, sticky-period:10m
+  failover: delay:1m, max-delay:10m
+  stickiness: period:10m, hostname:slave1, expires:2015-07-10 15:51:43+03
 
   id: 2
   active: false
   state: stopped
   resources: cpus:1.00, mem:2048, heap:1024, port:auto
-  failover: delay:1m, max-delay:10m, sticky-period:10m
+  failover: delay:1m, max-delay:10m
+  stickiness: period:10m, hostname:slave2, expires:2015-07-10 15:51:43+03
 
 #./kafka-mesos.sh start 0
 Broker 0 started
@@ -264,15 +268,21 @@ After each serial failure it doubles until it reaches failover-max-delay value.
 
 If failover-max-tries is defined and serial failure count exceeds it, broker will be deactivated.
 
-After failure but during failover-sticky-period time Scheduler would restart broker on the same node as before failure.
-After passing that time Scheduler would restart broker on any matched slave.
-
 Following failover settings exists:
 ```
---failover-delay    - initial failover delay to wait after failure, required
+--failover-delay     - initial failover delay to wait after failure, required
 --failover-max-delay - max failover delay, required
 --failover-max-tries - max failover tries to deactivate broker, optional
---failover-sticky-period - period during which failover will try to preserve same node for failed broker
+```
+
+Broker Placement Stickiness
+---------------------------
+If broker is started during stickiness-period time from it's stop time, scheduler will place the broker on the same node
+as it was during last successful start. This is related both to failover and manual restarts.
+
+Following stickiness settings exists:
+```
+--stickiness-period  - period of time during which broker would be restarted on the same node
 ```
 
 Navigating the CLI
@@ -294,7 +304,6 @@ Option                Description
 --failover-delay      failover delay (10s, 5m, 3h)
 --failover-max-delay  max failover delay. See failoverDelay.
 --failover-max-tries  max failover tries. Default - none
---failover-sticky-period  sticky period to preserve same node for broker (5m, 10m, 1h)
 --heap <Long>         heap amount in Mb
 --jvm-options         jvm options string (-Xms128m -XX:PermSize=48m)
 --log4j-options       log4j options or file. Examples:
@@ -305,6 +314,7 @@ Option                Description
                        log.dirs=/tmp/kafka/$id,num.io.threads=16
                        file:server.properties
 --port                port or range (31092, 31090..31100). Default - auto
+--stickiness-period   stickiness period to preserve same node for broker (5m, 10m, 1h)
 
 Generic Options
 Option  Description
@@ -345,7 +355,6 @@ Option                Description
 --failover-delay      failover delay (10s, 5m, 3h)
 --failover-max-delay  max failover delay. See failoverDelay.
 --failover-max-tries  max failover tries. Default - none
---failover-sticky-period  sticky period to preserve same node for broker (5m, 10m, 1h)
 --heap <Long>         heap amount in Mb
 --jvm-options         jvm options string (-Xms128m -XX:PermSize=48m)
 --log4j-options       log4j options or file. Examples:
@@ -356,6 +365,7 @@ Option                Description
                        log.dirs=/tmp/kafka/$id,num.io.threads=16
                        file:server.properties
 --port                port or range (31092, 31090..31100). Default - auto
+--stickiness-period   stickiness period to preserve same node for broker (5m, 10m, 1h)
 
 Generic Options
 Option  Description

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ broker:
   state: stopped
   resources: cpus:1.00, mem:2048, heap:1024, port:auto
   options: log.dirs=/mnt/array1/broker0
-  failover: delay:10s, max-delay:60s
+  failover: delay:1m, max-delay:10m, sticky-period:10m
 
 # ./kafka-mesos.sh start 0
 Broker 0 started
@@ -226,19 +226,19 @@ brokers:
   active: false
   state: stopped
   resources: cpus:1.00, mem:2048, heap:1024, port:auto
-  failover: delay:10s, max-delay:60s
+  failover: delay:1m, max-delay:10m, sticky-period:10m
 
   id: 1
   active: false
   state: stopped
   resources: cpus:1.00, mem:2048, heap:1024, port:auto
-  failover: delay:10s, max-delay:60s
+  failover: delay:1m, max-delay:10m, sticky-period:10m
 
   id: 2
   active: false
   state: stopped
   resources: cpus:1.00, mem:2048, heap:1024, port:auto
-  failover: delay:10s, max-delay:60s
+  failover: delay:1m, max-delay:10m, sticky-period:10m
 
 #./kafka-mesos.sh start 0
 Broker 0 started
@@ -259,16 +259,20 @@ clusterStorage=zk:/kafka-mesos
 Failed Broker Recovery
 ------------------------
 When the broker fails, kafka mesos scheduler assumes that the failure is recoverable. Scheduler will try
-to restart broker on any matched slave after waiting failover-delay (i.e. 30s, 2m). Initially waiting
-delay is equal to failover-delay setting. After each serial failure it doubles until it reaches failover-max-delay value.
+to restart broker after waiting failover-delay (i.e. 30s, 2m). Initially waiting delay is equal to failover-delay setting.
+After each serial failure it doubles until it reaches failover-max-delay value.
 
 If failover-max-tries is defined and serial failure count exceeds it, broker will be deactivated.
+
+After failure but during failover-sticky-period time Scheduler would restart broker on the same node as before failure.
+After passing that time Scheduler would restart broker on any matched slave.
 
 Following failover settings exists:
 ```
 --failover-delay    - initial failover delay to wait after failure, required
 --failover-max-delay - max failover delay, required
 --failover-max-tries - max failover tries to deactivate broker, optional
+--failover-sticky-period - period during which failover will try to preserve same node for failed broker
 ```
 
 Navigating the CLI
@@ -290,6 +294,7 @@ Option                Description
 --failover-delay      failover delay (10s, 5m, 3h)
 --failover-max-delay  max failover delay. See failoverDelay.
 --failover-max-tries  max failover tries. Default - none
+--failover-sticky-period  sticky period to preserve same node for broker (5m, 10m, 1h)
 --heap <Long>         heap amount in Mb
 --jvm-options         jvm options string (-Xms128m -XX:PermSize=48m)
 --log4j-options       log4j options or file. Examples:
@@ -340,6 +345,7 @@ Option                Description
 --failover-delay      failover delay (10s, 5m, 3h)
 --failover-max-delay  max failover delay. See failoverDelay.
 --failover-max-tries  max failover tries. Default - none
+--failover-sticky-period  sticky period to preserve same node for broker (5m, 10m, 1h)
 --heap <Long>         heap amount in Mb
 --jvm-options         jvm options string (-Xms128m -XX:PermSize=48m)
 --log4j-options       log4j options or file. Examples:

--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -220,6 +220,7 @@ object Broker {
 
     @volatile var failures: Int = 0
     @volatile var failureTime: Date = null
+    @volatile var successHostname: String = null
 
     def currentDelay: Period = {
       if (failures == 0) return new Period("0")
@@ -246,8 +247,13 @@ object Broker {
       failures += 1
       failureTime = now
     }
+    
+    def registerSuccess(hostname: String): Unit = {
+      resetFailures()
+      successHostname = hostname
+    }
 
-    def resetFailures(): Unit = {
+    def resetFailures(): Unit = { // todo remove me?
       failures = 0
       failureTime = null
     }
@@ -260,6 +266,7 @@ object Broker {
 
       if (node.contains("failures")) failures = node("failures").asInstanceOf[Number].intValue()
       if (node.contains("failureTime")) failureTime = dateTimeFormat.parse(node("failureTime").asInstanceOf[String])
+      if (node.contains("successHostname")) successHostname = node("successHostname").asInstanceOf[String]
     }
 
     def toJson: JSONObject = {
@@ -272,6 +279,7 @@ object Broker {
 
       if (failures != 0) obj("failures") = failures
       if (failureTime != null) obj("failureTime") = dateTimeFormat.format(failureTime)
+      if (successHostname != null) obj("successHostname") = successHostname
 
       new JSONObject(obj.toMap)
     }

--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -253,7 +253,7 @@ object Broker {
       successHostname = hostname
     }
 
-    def resetFailures(): Unit = { // todo remove me?
+    def resetFailures(): Unit = {
       failures = 0
       failureTime = null
     }

--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -23,7 +23,7 @@ import scala.util.parsing.json.JSONObject
 import scala.collection
 import org.apache.mesos.Protos.{Resource, Offer}
 import java.util.{TimeZone, Collections, Date, UUID}
-import ly.stealth.mesos.kafka.Broker.Failover
+import ly.stealth.mesos.kafka.Broker.{Stickiness, Failover}
 import ly.stealth.mesos.kafka.Util.{BindAddress, Period, Range, Str}
 import java.text.SimpleDateFormat
 
@@ -42,6 +42,7 @@ class Broker(_id: String = "0") {
   var log4jOptions: util.Map[String, String] = new util.LinkedHashMap()
   var jvmOptions: String = null
 
+  var stickiness: Stickiness = new Stickiness()
   var failover: Failover = new Failover()
 
   def options(defaults: util.Map[String, String] = null): util.Map[String, String] = {
@@ -111,9 +112,23 @@ class Broker(_id: String = "0") {
     -1
   }
 
-  def shouldStart(now: Date = new Date()): Boolean = active && task == null && !failover.isWaitingDelay(now)
+  def shouldStart(hostname: String, now: Date = new Date()): Boolean =
+    active && task == null &&
+    stickiness.allowsHostname(hostname, now) && !failover.isWaitingDelay(now)
 
   def shouldStop: Boolean = !active && task != null && !task.stopping
+  
+  def registerStart(hostname: String): Unit = {
+    stickiness.registerStart(hostname)
+    failover.resetFailures()
+  }
+
+  def registerStop(now: Date = new Date(), failed: Boolean = false): Unit = {
+    if (!failed || failover.failures == 0) stickiness.registerStop(now)
+
+    if (failed) failover.registerFailure(now)
+    else failover.resetFailures()
+  }
 
   def state(now: Date = new Date()): String = {
     if (task != null && !task.starting) return task.state
@@ -169,6 +184,7 @@ class Broker(_id: String = "0") {
     if (node.contains("log4jOptions")) log4jOptions = Util.parseMap(node("log4jOptions").asInstanceOf[String])
     if (node.contains("jvmOptions")) jvmOptions = node("jvmOptions").asInstanceOf[String]
 
+    if (node.contains("stickiness")) stickiness.fromJson(node("stickiness").asInstanceOf[Map[String, Object]])
     failover.fromJson(node("failover").asInstanceOf[Map[String, Object]])
 
     if (node.contains("task")) {
@@ -193,6 +209,7 @@ class Broker(_id: String = "0") {
     if (!log4jOptions.isEmpty) obj("log4jOptions") = Util.formatMap(log4jOptions)
     if (jvmOptions != null) obj("jvmOptions") = jvmOptions
 
+    obj("stickiness") = stickiness.toJson
     obj("failover") = failover.toJson
     if (task != null) obj("task") = task.toJson
 
@@ -212,15 +229,52 @@ object Broker {
 
   def isOptionOverridable(name: String): Boolean = !List("broker.id", "port", "zookeeper.connect").contains(name)
 
+  class Stickiness(_period: Period = new Period("10m")) {
+    var period: Period = _period
+    @volatile var hostname: String = null
+    @volatile var stopTime: Date = null
+
+    def expires: Date = if (stopTime != null) new Date(stopTime.getTime + period.ms) else null
+
+    def registerStart(hostname: String): Unit = {
+      this.hostname = hostname
+      stopTime = null
+    }
+
+    def registerStop(now: Date = new Date()): Unit = {
+      this.stopTime = now
+    }
+
+    def allowsHostname(hostname: String, now: Date = new Date()): Boolean = {
+      if (this.hostname == null) return true
+      if (stopTime == null || now.getTime - stopTime.getTime >= period.ms) return true
+      this.hostname == hostname
+    }
+
+    def fromJson(node: Map[String, Object]): Unit = {
+      period = new Period(node("period").asInstanceOf[String])
+      if (node.contains("stopTime")) stopTime = dateTimeFormat.parse(node("stopTime").asInstanceOf[String])
+      if (node.contains("hostname")) hostname = node("hostname").asInstanceOf[String]
+    }
+
+    def toJson: JSONObject = {
+      val obj = new collection.mutable.LinkedHashMap[String, Any]()
+
+      obj("period") = "" + period
+      if (stopTime != null) obj("stopTime") = dateTimeFormat.format(stopTime)
+      if (hostname != null) obj("hostname") = hostname
+
+      new JSONObject(obj.toMap)
+    }
+  }
+
   class Failover(_delay: Period = new Period("1m"), _maxDelay: Period = new Period("10m"), _stickyPeriod: Period = new Period("10m")) {
     var delay: Period = _delay
     var maxDelay: Period = _maxDelay
     var maxTries: Integer = null
-    var stickyPeriod: Period = _stickyPeriod
 
     @volatile var failures: Int = 0
     @volatile var failureTime: Date = null
-    @volatile var successHostname: String = null
 
     def currentDelay: Period = {
       if (failures == 0) return new Period("0")
@@ -247,11 +301,6 @@ object Broker {
       failures += 1
       failureTime = now
     }
-    
-    def registerSuccess(hostname: String): Unit = {
-      resetFailures()
-      successHostname = hostname
-    }
 
     def resetFailures(): Unit = {
       failures = 0
@@ -262,11 +311,9 @@ object Broker {
       delay = new Period(node("delay").asInstanceOf[String])
       maxDelay = new Period(node("maxDelay").asInstanceOf[String])
       if (node.contains("maxTries")) maxTries = node("maxTries").asInstanceOf[Number].intValue()
-      stickyPeriod = if (node.contains("stickyPeriod")) new Period(node("stickyPeriod").asInstanceOf[String]) else new Period("10m")
 
       if (node.contains("failures")) failures = node("failures").asInstanceOf[Number].intValue()
       if (node.contains("failureTime")) failureTime = dateTimeFormat.parse(node("failureTime").asInstanceOf[String])
-      if (node.contains("successHostname")) successHostname = node("successHostname").asInstanceOf[String]
     }
 
     def toJson: JSONObject = {
@@ -275,11 +322,9 @@ object Broker {
       obj("delay") = "" + delay
       obj("maxDelay") = "" + maxDelay
       if (maxTries != null) obj("maxTries") = maxTries
-      obj("stickyPeriod") = "" + stickyPeriod
 
       if (failures != 0) obj("failures") = failures
       if (failureTime != null) obj("failureTime") = dateTimeFormat.format(failureTime)
-      if (successHostname != null) obj("successHostname") = successHostname
 
       new JSONObject(obj.toMap)
     }

--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -268,7 +268,7 @@ object Broker {
     }
   }
 
-  class Failover(_delay: Period = new Period("1m"), _maxDelay: Period = new Period("10m"), _stickyPeriod: Period = new Period("10m")) {
+  class Failover(_delay: Period = new Period("1m"), _maxDelay: Period = new Period("10m")) {
     var delay: Period = _delay
     var maxDelay: Period = _maxDelay
     var maxTries: Integer = null

--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -212,10 +212,11 @@ object Broker {
 
   def isOptionOverridable(name: String): Boolean = !List("broker.id", "port", "zookeeper.connect").contains(name)
 
-  class Failover(_delay: Period = new Period("10s"), _maxDelay: Period = new Period("60s")) {
+  class Failover(_delay: Period = new Period("1m"), _maxDelay: Period = new Period("10m"), _stickyPeriod: Period = new Period("10m")) {
     var delay: Period = _delay
     var maxDelay: Period = _maxDelay
     var maxTries: Integer = null
+    var stickyPeriod: Period = _stickyPeriod
 
     @volatile var failures: Int = 0
     @volatile var failureTime: Date = null
@@ -255,6 +256,7 @@ object Broker {
       delay = new Period(node("delay").asInstanceOf[String])
       maxDelay = new Period(node("maxDelay").asInstanceOf[String])
       if (node.contains("maxTries")) maxTries = node("maxTries").asInstanceOf[Number].intValue()
+      stickyPeriod = if (node.contains("stickyPeriod")) new Period(node("stickyPeriod").asInstanceOf[String]) else new Period("10m")
 
       if (node.contains("failures")) failures = node("failures").asInstanceOf[Number].intValue()
       if (node.contains("failureTime")) failureTime = dateTimeFormat.parse(node("failureTime").asInstanceOf[String])
@@ -266,6 +268,7 @@ object Broker {
       obj("delay") = "" + delay
       obj("maxDelay") = "" + maxDelay
       if (maxTries != null) obj("maxTries") = maxTries
+      obj("stickyPeriod") = "" + stickyPeriod
 
       if (failures != 0) obj("failures") = failures
       if (failureTime != null) obj("failureTime") = dateTimeFormat.format(failureTime)

--- a/src/scala/ly/stealth/mesos/kafka/Cli.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cli.scala
@@ -271,6 +271,7 @@ object Cli {
     parser.accepts("failover-delay", "failover delay (10s, 5m, 3h)").withRequiredArg().ofType(classOf[String])
     parser.accepts("failover-max-delay", "max failover delay. See failoverDelay.").withRequiredArg().ofType(classOf[String])
     parser.accepts("failover-max-tries", "max failover tries. Default - none").withRequiredArg().ofType(classOf[String])
+    parser.accepts("failover-sticky-period", "sticky period to preserve same node for broker (5m, 10m, 1h)").withRequiredArg().ofType(classOf[String])
 
     if (help) {
       val command = if (add) "add" else "update"
@@ -313,6 +314,7 @@ object Cli {
     val failoverDelay = options.valueOf("failover-delay").asInstanceOf[String]
     val failoverMaxDelay = options.valueOf("failover-max-delay").asInstanceOf[String]
     val failoverMaxTries = options.valueOf("failover-max-tries").asInstanceOf[String]
+    val failoverStickyPeriod = options.valueOf("failover-sticky-period").asInstanceOf[String]
 
     val params = new util.LinkedHashMap[String, String]
     params.put("id", id)
@@ -331,6 +333,7 @@ object Cli {
     if (failoverDelay != null) params.put("failoverDelay", failoverDelay)
     if (failoverMaxDelay != null) params.put("failoverMaxDelay", failoverMaxDelay)
     if (failoverMaxTries != null) params.put("failoverMaxTries", failoverMaxTries)
+    if (failoverStickyPeriod != null) params.put("failoverStickyPeriod", failoverStickyPeriod)
 
     var json: Map[String, Object] = null
     try { json = sendRequest("/brokers/" + (if (add) "add" else "update"), params) }
@@ -559,6 +562,7 @@ object Cli {
     failover += " delay:" + broker.failover.delay
     failover += ", max-delay:" + broker.failover.maxDelay
     if (broker.failover.maxTries != null) failover += ", max-tries:" + broker.failover.maxTries
+    failover += ", sticky-period:" + broker.failover.stickyPeriod
     printLine(failover, indent)
 
     val task = broker.task

--- a/src/scala/ly/stealth/mesos/kafka/Cli.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cli.scala
@@ -24,7 +24,7 @@ import java.io._
 import java.util
 import scala.collection.JavaConversions._
 import java.util.{Properties, Collections}
-import ly.stealth.mesos.kafka.Util.Period
+import ly.stealth.mesos.kafka.Util.{Str, Period}
 
 object Cli {
   var api: String = null
@@ -262,6 +262,7 @@ object Cli {
     parser.accepts("heap", "heap amount in Mb").withRequiredArg().ofType(classOf[java.lang.Long])
     parser.accepts("port", "port or range (31092, 31090..31100). Default - auto").withRequiredArg().ofType(classOf[java.lang.String])
     parser.accepts("bind-address", "broker bind address (broker0, 192.168.50.*, if:eth1). Default - auto").withRequiredArg().ofType(classOf[java.lang.String])
+    parser.accepts("stickiness-period", "stickiness period to preserve same node for broker (5m, 10m, 1h)").withRequiredArg().ofType(classOf[String])
 
     parser.accepts("options", "options or file. Examples:\n log.dirs=/tmp/kafka/$id,num.io.threads=16\n file:server.properties").withRequiredArg()
     parser.accepts("log4j-options", "log4j options or file. Examples:\n log4j.logger.kafka=DEBUG\\, kafkaAppender\n file:log4j.properties").withRequiredArg()
@@ -271,7 +272,6 @@ object Cli {
     parser.accepts("failover-delay", "failover delay (10s, 5m, 3h)").withRequiredArg().ofType(classOf[String])
     parser.accepts("failover-max-delay", "max failover delay. See failoverDelay.").withRequiredArg().ofType(classOf[String])
     parser.accepts("failover-max-tries", "max failover tries. Default - none").withRequiredArg().ofType(classOf[String])
-    parser.accepts("failover-sticky-period", "sticky period to preserve same node for broker (5m, 10m, 1h)").withRequiredArg().ofType(classOf[String])
 
     if (help) {
       val command = if (add) "add" else "update"
@@ -305,6 +305,7 @@ object Cli {
     val heap = options.valueOf("heap").asInstanceOf[java.lang.Long]
     val port = options.valueOf("port").asInstanceOf[String]
     val bindAddress = options.valueOf("bind-address").asInstanceOf[String]
+    val stickinessPeriod = options.valueOf("stickiness-period").asInstanceOf[String]
 
     val constraints = options.valueOf("constraints").asInstanceOf[String]
     val options_ = options.valueOf("options").asInstanceOf[String]
@@ -314,7 +315,6 @@ object Cli {
     val failoverDelay = options.valueOf("failover-delay").asInstanceOf[String]
     val failoverMaxDelay = options.valueOf("failover-max-delay").asInstanceOf[String]
     val failoverMaxTries = options.valueOf("failover-max-tries").asInstanceOf[String]
-    val failoverStickyPeriod = options.valueOf("failover-sticky-period").asInstanceOf[String]
 
     val params = new util.LinkedHashMap[String, String]
     params.put("id", id)
@@ -324,6 +324,7 @@ object Cli {
     if (heap != null) params.put("heap", "" + heap)
     if (port != null) params.put("port", port)
     if (bindAddress != null) params.put("bindAddress", bindAddress)
+    if (stickinessPeriod != null) params.put("stickinessPeriod", stickinessPeriod)
 
     if (options_ != null) params.put("options", optionsOrFile(options_))
     if (constraints != null) params.put("constraints", constraints)
@@ -333,7 +334,6 @@ object Cli {
     if (failoverDelay != null) params.put("failoverDelay", failoverDelay)
     if (failoverMaxDelay != null) params.put("failoverMaxDelay", failoverMaxDelay)
     if (failoverMaxTries != null) params.put("failoverMaxTries", failoverMaxTries)
-    if (failoverStickyPeriod != null) params.put("failoverStickyPeriod", failoverStickyPeriod)
 
     var json: Map[String, Object] = null
     try { json = sendRequest("/brokers/" + (if (add) "add" else "update"), params) }
@@ -562,8 +562,13 @@ object Cli {
     failover += " delay:" + broker.failover.delay
     failover += ", max-delay:" + broker.failover.maxDelay
     if (broker.failover.maxTries != null) failover += ", max-tries:" + broker.failover.maxTries
-    failover += ", sticky-period:" + broker.failover.stickyPeriod
     printLine(failover, indent)
+
+    var stickiness = "stickiness:"
+    stickiness += " period:" + broker.stickiness.period
+    if (broker.stickiness.hostname != null) stickiness += ", hostname:" + broker.stickiness.hostname
+    if (broker.stickiness.stopTime != null) stickiness += ", expires:" + Str.dateTime(broker.stickiness.expires)
+    printLine(stickiness, indent)
 
     val task = broker.task
     if (task != null) {

--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -166,6 +166,11 @@ object HttpServer {
         try { new BindAddress(request.getParameter("bindAddress")) }
         catch { case e: IllegalArgumentException => errors.add("Invalid bindAddress") }
 
+      var stickinessPeriod: Period = null
+      if (request.getParameter("stickinessPeriod") != null)
+        try { stickinessPeriod = new Period(request.getParameter("stickinessPeriod")) }
+        catch { case e: IllegalArgumentException => errors.add("Invalid stickinessPeriod") }
+
       var options: util.Map[String, String] = null
       if (request.getParameter("options") != null)
         try { options = Util.parseMap(request.getParameter("options"), nullValues = false).filterKeys(Broker.isOptionOverridable).view.force }
@@ -199,11 +204,6 @@ object HttpServer {
         try { Integer.valueOf(failoverMaxTries) }
         catch { case e: NumberFormatException => errors.add("Invalid failoverMaxTries") }
 
-      var failoverStickyPeriod: Period = null
-      if (request.getParameter("failoverStickyPeriod") != null)
-        try { failoverStickyPeriod = new Period(request.getParameter("failoverStickyPeriod")) }
-        catch { case e: IllegalArgumentException => errors.add("Invalid failoverStickyPeriod") }
-
 
       if (!errors.isEmpty) { response.sendError(400, errors.mkString("; ")); return }
 
@@ -234,6 +234,7 @@ object HttpServer {
         if (heap != null) broker.heap = heap
         if (port != null) broker.port = if (port != "") new Range(port) else null
         if (bindAddress != null) broker.bindAddress = if (bindAddress != "") new BindAddress(bindAddress) else null
+        if (stickinessPeriod != null) broker.stickiness.period = stickinessPeriod
 
         if (constraints != null) broker.constraints = constraints
         if (options != null) broker.options = options
@@ -243,7 +244,6 @@ object HttpServer {
         if (failoverDelay != null) broker.failover.delay = failoverDelay
         if (failoverMaxDelay != null) broker.failover.maxDelay = failoverMaxDelay
         if (failoverMaxTries != null) broker.failover.maxTries = if (failoverMaxTries != "") Integer.valueOf(failoverMaxTries) else null
-        if (failoverStickyPeriod != null) broker.failover.stickyPeriod = failoverStickyPeriod
 
         if (add) cluster.addBroker(broker)
       }

--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -199,6 +199,11 @@ object HttpServer {
         try { Integer.valueOf(failoverMaxTries) }
         catch { case e: NumberFormatException => errors.add("Invalid failoverMaxTries") }
 
+      var failoverStickyPeriod: Period = null
+      if (request.getParameter("failoverStickyPeriod") != null)
+        try { failoverStickyPeriod = new Period(request.getParameter("failoverStickyPeriod")) }
+        catch { case e: IllegalArgumentException => errors.add("Invalid failoverStickyPeriod") }
+
 
       if (!errors.isEmpty) { response.sendError(400, errors.mkString("; ")); return }
 
@@ -238,6 +243,7 @@ object HttpServer {
         if (failoverDelay != null) broker.failover.delay = failoverDelay
         if (failoverMaxDelay != null) broker.failover.maxDelay = failoverMaxDelay
         if (failoverMaxTries != null) broker.failover.maxTries = if (failoverMaxTries != "") Integer.valueOf(failoverMaxTries) else null
+        if (failoverStickyPeriod != null) broker.failover.stickyPeriod = failoverStickyPeriod
 
         if (add) cluster.addBroker(broker)
       }

--- a/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
@@ -215,7 +215,7 @@ object Scheduler extends org.apache.mesos.Scheduler {
       logger.info(s"Finished reconciling of broker ${broker.id}, task ${broker.task.id}")
 
     broker.task.state = Broker.State.RUNNING
-    broker.failover.resetFailures()
+    broker.failover.registerSuccess(broker.task.hostname)
   }
 
   private[kafka] def onBrokerStopped(broker: Broker, status: TaskStatus, now: Date = new Date()): Unit = {

--- a/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
@@ -173,7 +173,7 @@ object Scheduler extends org.apache.mesos.Scheduler {
     if (isReconciling) return "reconciling"
 
     var reason = ""
-    for (broker <- cluster.getBrokers.filter(_.shouldStart())) {
+    for (broker <- cluster.getBrokers.filter(_.shouldStart(offer.getHostname))) {
       val diff = broker.matches(offer, otherTasksAttributes)
 
       if (diff == null) {
@@ -215,16 +215,16 @@ object Scheduler extends org.apache.mesos.Scheduler {
       logger.info(s"Finished reconciling of broker ${broker.id}, task ${broker.task.id}")
 
     broker.task.state = Broker.State.RUNNING
-    broker.failover.registerSuccess(broker.task.hostname)
+    broker.registerStart(broker.task.hostname)
   }
 
   private[kafka] def onBrokerStopped(broker: Broker, status: TaskStatus, now: Date = new Date()): Unit = {
     broker.task = null
+
     val failed = broker.active && status.getState != TaskState.TASK_FINISHED && status.getState != TaskState.TASK_KILLED
+    broker.registerStop(now, failed)
 
     if (failed) {
-      broker.failover.registerFailure(now)
-
       var msg = s"Broker ${broker.id} failed ${broker.failover.failures}"
       if (broker.failover.maxTries != null) msg += "/" + broker.failover.maxTries
 

--- a/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
@@ -22,7 +22,7 @@ import org.junit.Assert._
 import ly.stealth.mesos.kafka.Util.{BindAddress, Period, parseMap}
 import java.util.Date
 import scala.collection.JavaConversions._
-import ly.stealth.mesos.kafka.Broker.{State, Task, Failover}
+import ly.stealth.mesos.kafka.Broker.{Stickiness, State, Task, Failover}
 
 class BrokerTest extends MesosTestCase {
   var broker: Broker = null
@@ -143,28 +143,36 @@ class BrokerTest extends MesosTestCase {
 
   @Test
   def shouldStart {
+    val host = "host"
     // active
     broker.active = false
-    assertFalse(broker.shouldStart())
+    assertFalse(broker.shouldStart(host))
     broker.active = true
-    assertTrue(broker.shouldStart())
+    assertTrue(broker.shouldStart(host))
 
     // has task
     broker.task = new Task()
-    assertFalse(broker.shouldStart())
+    assertFalse(broker.shouldStart(host))
     broker.task = null
-    assertTrue(broker.shouldStart())
+    assertTrue(broker.shouldStart(host))
+
+    // sticky hostname
+    broker.registerStart(host)
+    broker.registerStop(new Date(0))
+    assertTrue(broker.shouldStart(host, new Date(0)))
+    assertFalse(broker.shouldStart(host + "1", new Date(0)))
+    assertTrue(broker.shouldStart(host + "1", new Date(broker.stickiness.period.ms)))
 
     // failover waiting delay
     val now = new Date(0)
     broker.failover.delay = new Period("1s")
-    broker.failover.registerFailure(now)
+    broker.registerStop(now, failed = true)
     assertTrue(broker.failover.isWaitingDelay(now))
 
-    assertFalse(broker.shouldStart(now = now))
-    assertTrue(broker.shouldStart(now = new Date(now.getTime + broker.failover.delay.ms)))
+    assertFalse(broker.shouldStart(host, now = now))
+    assertTrue(broker.shouldStart(host, now = new Date(now.getTime + broker.failover.delay.ms)))
     broker.failover.resetFailures()
-    assertTrue(broker.shouldStart(now = now))
+    assertTrue(broker.shouldStart(host, now = now))
   }
 
   @Test
@@ -258,6 +266,52 @@ class BrokerTest extends MesosTestCase {
     assertEquals("0", Broker.idFromTaskId(Broker.nextTaskId(new Broker("0"))))
     assertEquals("100", Broker.idFromTaskId(Broker.nextTaskId(new Broker("100"))))
   }
+  
+  // Stickiness
+  @Test
+  def Stickiness_allowsHostname {
+    val stickiness = new Stickiness()
+    assertTrue(stickiness.allowsHostname("host0", new Date(0)))
+    assertTrue(stickiness.allowsHostname("host1", new Date(0)))
+
+    stickiness.registerStart("host0")
+    stickiness.registerStop(new Date(0))
+    assertTrue(stickiness.allowsHostname("host0", new Date(0)))
+    assertFalse(stickiness.allowsHostname("host1", new Date(0)))
+    assertTrue(stickiness.allowsHostname("host1", new Date(stickiness.period.ms)))
+  }
+
+  @Test
+  def Stickiness_registerStart_registerStop {
+    val stickiness = new Stickiness()
+    assertNull(stickiness.hostname)
+    assertNull(stickiness.stopTime)
+
+    stickiness.registerStart("host")
+    assertEquals("host", stickiness.hostname)
+    assertNull(stickiness.stopTime)
+
+    stickiness.registerStop(new Date(0))
+    assertEquals("host", stickiness.hostname)
+    assertEquals(new Date(0), stickiness.stopTime)
+
+    stickiness.registerStart("host1")
+    assertEquals("host1", stickiness.hostname)
+    assertNull(stickiness.stopTime)
+  }
+
+  @Test
+  def Stickiness_toJson_fromJson {
+    val stickiness = new Stickiness()
+    stickiness.registerStart("localhost")
+    stickiness.registerStop(new Date(0))
+
+    val read: Stickiness = new Stickiness()
+    read.fromJson(Util.parseJson("" + stickiness.toJson))
+
+    BrokerTest.assertStickinessEquals(stickiness, read)
+  }
+  
 
   // Failover
   @Test
@@ -320,7 +374,7 @@ class BrokerTest extends MesosTestCase {
   }
 
   @Test
-  def Failover_registerFailure_registerSuccess {
+  def Failover_registerFailure_resetFailures {
     val failover = new Failover()
     assertEquals(0, failover.failures)
     assertNull(failover.failureTime)
@@ -333,22 +387,19 @@ class BrokerTest extends MesosTestCase {
     assertEquals(2, failover.failures)
     assertEquals(new Date(2), failover.failureTime)
 
-    failover.registerSuccess("localhost")
+    failover.resetFailures()
     assertEquals(0, failover.failures)
     assertNull(failover.failureTime)
-    assertEquals("localhost", failover.successHostname)
 
     failover.registerFailure()
     assertEquals(1, failover.failures)
-    assertEquals("localhost", failover.successHostname)
   }
 
   @Test
   def Failover_toJson_fromJson {
     val failover = new Failover(new Period("1s"), new Period("5s"))
-    failover.stickyPeriod = new Period("5m")
     failover.maxTries = 10
-    failover.registerSuccess("localhost")
+    failover.resetFailures()
     failover.registerFailure(new Date(0))
 
     val read: Failover = new Failover()
@@ -397,11 +448,17 @@ object BrokerTest {
     assertEquals(expected.delay, actual.delay)
     assertEquals(expected.maxDelay, actual.maxDelay)
     assertEquals(expected.maxTries, actual.maxTries)
-    assertEquals(expected.stickyPeriod, actual.stickyPeriod)
 
     assertEquals(expected.failures, actual.failures)
     assertEquals(expected.failureTime, actual.failureTime)
-    assertEquals(expected.successHostname, actual.successHostname)
+  }
+
+  def assertStickinessEquals(expected: Stickiness, actual: Stickiness) {
+    if (checkNulls(expected, actual)) return
+
+    assertEquals(expected.period, actual.period)
+    assertEquals(expected.stopTime, actual.stopTime)
+    assertEquals(expected.hostname, actual.hostname)
   }
 
   def assertTaskEquals(expected: Task, actual: Task) {

--- a/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
@@ -156,7 +156,7 @@ class BrokerTest extends MesosTestCase {
     broker.task = null
     assertTrue(broker.shouldStart(host))
 
-    // sticky hostname
+    // stickiness
     broker.registerStart(host)
     broker.registerStop(new Date(0))
     assertTrue(broker.shouldStart(host, new Date(0)))

--- a/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
@@ -320,7 +320,7 @@ class BrokerTest extends MesosTestCase {
   }
 
   @Test
-  def Failover_registerFailure_resetFailures {
+  def Failover_registerFailure_registerSuccess {
     val failover = new Failover()
     assertEquals(0, failover.failures)
     assertNull(failover.failureTime)
@@ -333,9 +333,14 @@ class BrokerTest extends MesosTestCase {
     assertEquals(2, failover.failures)
     assertEquals(new Date(2), failover.failureTime)
 
-    failover.resetFailures()
+    failover.registerSuccess("localhost")
     assertEquals(0, failover.failures)
     assertNull(failover.failureTime)
+    assertEquals("localhost", failover.successHostname)
+
+    failover.registerFailure()
+    assertEquals(1, failover.failures)
+    assertEquals("localhost", failover.successHostname)
   }
 
   @Test
@@ -343,6 +348,7 @@ class BrokerTest extends MesosTestCase {
     val failover = new Failover(new Period("1s"), new Period("5s"))
     failover.stickyPeriod = new Period("5m")
     failover.maxTries = 10
+    failover.registerSuccess("localhost")
     failover.registerFailure(new Date(0))
 
     val read: Failover = new Failover()
@@ -395,6 +401,7 @@ object BrokerTest {
 
     assertEquals(expected.failures, actual.failures)
     assertEquals(expected.failureTime, actual.failureTime)
+    assertEquals(expected.successHostname, actual.successHostname)
   }
 
   def assertTaskEquals(expected: Task, actual: Task) {

--- a/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
@@ -341,6 +341,7 @@ class BrokerTest extends MesosTestCase {
   @Test
   def Failover_toJson_fromJson {
     val failover = new Failover(new Period("1s"), new Period("5s"))
+    failover.stickyPeriod = new Period("5m")
     failover.maxTries = 10
     failover.registerFailure(new Date(0))
 
@@ -390,6 +391,7 @@ object BrokerTest {
     assertEquals(expected.delay, actual.delay)
     assertEquals(expected.maxDelay, actual.maxDelay)
     assertEquals(expected.maxTries, actual.maxTries)
+    assertEquals(expected.stickyPeriod, actual.stickyPeriod)
 
     assertEquals(expected.failures, actual.failures)
     assertEquals(expected.failureTime, actual.failureTime)


### PR DESCRIPTION
Hey,

Just added support of --stickiness-period option of add|update commands.
Those period is used if broker is restarted by failover or manually.

Please review & merge.
