### PR TITLE
scheduler_bind_address

### DIFF
--- a/src/scala/ly/stealth/mesos/kafka/Cli.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cli.scala
@@ -24,7 +24,7 @@ import java.io._
 import java.util
 import scala.collection.JavaConversions._
 import java.util.{Properties, Collections}
-import ly.stealth.mesos.kafka.Util.{Str, Period}
+import ly.stealth.mesos.kafka.Util.{BindAddress, Str, Period}
 
 object Cli {
   var api: String = null
@@ -143,6 +143,9 @@ object Cli {
     parser.accepts("api", "Api url. Example: http://master:7000")
       .withRequiredArg().ofType(classOf[String])
 
+    parser.accepts("bind-address", "Scheduler bind address (master, 0.0.0.0, 192.168.50.*, if:eth1). Default - all")
+      .withRequiredArg().ofType(classOf[String])
+
     parser.accepts("zk",
       """Kafka zookeeper.connect. Examples:
         | - master:2181
@@ -220,6 +223,11 @@ object Cli {
     val api = options.valueOf("api").asInstanceOf[String]
     if (api != null) Config.api = api
     else if (Config.api == null) throw new Error(s"Undefined api. $provideOption")
+
+    val bindAddress = options.valueOf("bind-address").asInstanceOf[String]
+    if (bindAddress != null)
+      try { Config.bindAddress = new BindAddress(bindAddress) }
+      catch { case e: IllegalArgumentException => throw new Error("Invalid bind-address") }
 
     val zk = options.valueOf("zk").asInstanceOf[String]
     if (zk != null) Config.zk = zk

--- a/src/scala/ly/stealth/mesos/kafka/Config.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Config.scala
@@ -20,7 +20,7 @@ package ly.stealth.mesos.kafka
 import java.io.{FileInputStream, File}
 import java.util.Properties
 import java.net.URI
-import ly.stealth.mesos.kafka.Util.Period
+import ly.stealth.mesos.kafka.Util.{BindAddress, Period}
 
 object Config {
   val DEFAULT_FILE = new File("kafka-mesos.properties")
@@ -40,6 +40,7 @@ object Config {
   var jre: File = null
   var log: File = null
   var api: String = null
+  var bindAddress: BindAddress = null
   var zk: String = null
 
   def apiPort: Int = {
@@ -69,6 +70,7 @@ object Config {
     if (props.containsKey("jre")) jre = new File(props.getProperty("jre"))
     if (props.containsKey("log")) log = new File(props.getProperty("log"))
     if (props.containsKey("api")) api = props.getProperty("api")
+    if (props.containsKey("bind-address")) bindAddress = new BindAddress(props.getProperty("bind-address"))
     if (props.containsKey("zk")) zk = props.getProperty("zk")
   }
 
@@ -77,7 +79,7 @@ object Config {
       |debug: $debug, storage: $storage
       |mesos: master=$master, user=${if (user == null || user.isEmpty) "<default>" else user}, principal=${if (principal != null) principal else "<none>"}, secret=${if (secret != null) "*****" else "<none>"}
       |framework: name=$frameworkName, role=$frameworkRole, timeout=$frameworkTimeout
-      |api: $api, zk: $zk, jre: ${if (jre == null) "<none>" else jre}
+      |api: $api, bind-address: ${if (bindAddress != null) bindAddress else "<all>"}, zk: $zk, jre: ${if (jre == null) "<none>" else jre}
     """.stripMargin.trim
   }
 }

--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -47,6 +47,7 @@ object HttpServer {
     server = new Server(threadPool)
     val connector = new ServerConnector(server)
     connector.setPort(Config.apiPort)
+    if (Config.bindAddress != null) connector.setHost(Config.bindAddress.resolve())
     connector.setIdleTimeout(60 * 1000)
 
     val handler = new ServletContextHandler
@@ -181,7 +182,7 @@ object HttpServer {
         try { log4jOptions = Util.parseMap(request.getParameter("log4jOptions")) }
         catch { case e: IllegalArgumentException => errors.add("Invalid log4jOptions: " + e.getMessage) }
 
-      var jvmOptions: String = request.getParameter("jvmOptions")
+      val jvmOptions: String = request.getParameter("jvmOptions")
 
       var constraints: util.Map[String, Constraint] = null
       if (request.getParameter("constraints") != null)


### PR DESCRIPTION
By default scheduler binds it's http API to 0.0.0.0 which stands for 'all addresses'. Sometimes user may want to use just specific address. For that purpose --bind-address option is provided for `scheduler` sub-command. Format is just the same as for specifying broker's bind-address. 

Please review & merge.
