### PR TITLE
Create parent paths in zookeeper if they do not exist

### DIFF
--- a/src/scala/ly/stealth/mesos/kafka/Cluster.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cluster.scala
@@ -159,6 +159,15 @@ object Cluster {
   }
 
   class ZkStorage(val path: String) extends Storage {
+    {
+      val (zkConnect, chroot) = Config.zk.span(_ != '/')
+      if (chroot != "") {
+        val client = new ZkClient(zkConnect, 30000, 30000, ZKStringSerializer)
+        try { client.createPersistent(chroot, false) }
+        finally { client.close() }
+      }
+    }
+
     def zkClient: ZkClient = new ZkClient(Config.zk, 30000, 30000, ZKStringSerializer)
 
     protected def loadJson: String = {

--- a/src/scala/ly/stealth/mesos/kafka/Cluster.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cluster.scala
@@ -161,9 +161,10 @@ object Cluster {
   class ZkStorage(val path: String) extends Storage {
     {
       val (zkConnect, chroot) = Config.zk.span(_ != '/')
-      if (chroot != "") {
+      val storagePath = chroot + path
+      if (storagePath != "") {
         val client = new ZkClient(zkConnect, 30000, 30000, ZKStringSerializer)
-        try { client.createPersistent(chroot, false) }
+        try { client.createPersistent(storagePath, true) }
         finally { client.close() }
       }
     }


### PR DESCRIPTION
This should fix #82. 
When using configuration like `--zk=host:2181/kafka-outbound-broker --storage=zk:/kafka-outbound-scheduler` and `/kafka-outbound-broker` znode does not exist the scheduler would fail saving state to zookeeper and misbehave. This PR creates parent paths if necessary.
