### PR TITLE
Fixed taskBuilder to set role for cpus and mem resources.

### DIFF
--- a/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
@@ -84,8 +84,8 @@ object Scheduler extends org.apache.mesos.Scheduler {
       .setExecutor(newExecutor(broker))
 
     taskBuilder
-      .addResources(Resource.newBuilder.setName("cpus").setType(Value.Type.SCALAR).setScalar(Value.Scalar.newBuilder.setValue(broker.cpus)))
-      .addResources(Resource.newBuilder.setName("mem").setType(Value.Type.SCALAR).setScalar(Value.Scalar.newBuilder.setValue(broker.mem)))
+      .addResources(Resource.newBuilder.setName("cpus").setType(Value.Type.SCALAR).setScalar(Value.Scalar.newBuilder.setValue(broker.cpus)).setRole(Config.frameworkRole))
+      .addResources(Resource.newBuilder.setName("mem").setType(Value.Type.SCALAR).setScalar(Value.Scalar.newBuilder.setValue(broker.mem)).setRole(Config.frameworkRole))
       .addResources(Resource.newBuilder.setName("ports").setType(Value.Type.RANGES).setRanges(
       Value.Ranges.newBuilder.addRange(Value.Range.newBuilder().setBegin(port).setEnd(port)))
       )


### PR DESCRIPTION
In trying to use kafka-mesos with a framework role which had specific mesos-slave resources assigned to it, I found that submitted tasks were using the \* role despite my framework role having registered. The following enhanced logs demonstrate the issue:

First - note that the role was set to "kafka" (creatively named).

```
2015-08-01 08:09:22,952 [main] INFO  ly.stealth.mesos.kafka.Scheduler$  - Starting Scheduler$:
debug: false, storage: zk:/kafka-mesos
mesos: master=zk://###.###.66.12:2181,###.###.66.17:2181,###.###.66.23:2181/mesos, user=<default>, principal=<none>, secret=<none>
framework: name=kafka, role=kafka, timeout=30d
api: http://bgd0005d1.acme.com:7000, bind-address: <all>, zk: ###.###.66.12:2181,###.###.66.17:2181,###.###.66.23:2181, jre: <none>
```

```
bgd0004d1.acme.com#-O445 cpus:32.00 mem:515816.00 disk:1843834.00 ports:[4000..32000] purpose:compute;storagemedia:magnetic
bgd0006d1.acme.com#-O446 cpus:32.00 mem:515816.00 disk:1843834.00 ports:[4000..32000] purpose:admin;storagemedia:magnetic
bgd0018d1.acme.com#-O447 cpus:32.00 mem:257273.00 disk:1843834.00 ports:[4000..32000] purpose:compute;storagemedia:ssd
bgd0001d1.acme.com#-O461 cpus:32.00 mem:515816.00 disk:1843834.00 ports:[4000..32000] purpose:admin;storagemedia:magnetic
2015-08-01 08:10:41,324 [Thread-67] INFO  ly.stealth.mesos.kafka.Scheduler$  - Starting broker 0: launching task broker-0-0e042dac-a4ff-474e-9909-44aa2229c84b by offer bgd0006d1.acme.com#-O446
 broker-0-0e042dac-a4ff-474e-9909-44aa2229c84b slave:#34-S4 cpus:5.00 mem:6000.00 ports:[9092..9092] data:defaults=broker.id\=0\,log.dirs\=kafka-logs\,port\=9092\,zookeeper.connect\=###.###.66.12:2181\\\,###.###.66.17:2181\\\,###.###.66.23:2181\,host.name\=bgd0006d1.acme.com\,log.retention.bytes\=10737418240,broker={"stickiness" : {"period" : "24h"}\, "bindAddress" : "if:eth4"\, "options" : "log.flush.interval.ms\=10000\,delete.topic.enable\=true\,num.network.threads\=8\,offsets.storage\=kafka\,log.dirs\=\\/a\\/kafka\\/0\\/kafka-logs\,num.replica.fetchers\=4\,num.io.threads\=8\,auto.create.topics.enable\=false"\, "id" : "0"\, "port" : "9092"\, "constraints" : "purpose\=cluster:admin"\, "mem" : 6000\, "jvmOptions" : "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port\=9990 -Dcom.sun.management.jmxremote.local.only\=false -Dcom.sun.management.jmxremote.authenticate\=false -Dcom.sun.management.jmxremote.ssl\=false"\, "cpus" : 5.0\, "heap" : 4000\, "failover" : {"delay" : "1m"\, "maxDelay" : "10m"}\, "active" : true}
2015-08-01 08:10:41,326 [Thread-67] INFO  ly.stealth.mesos.kafka.Scheduler$  - Declined offers:
bgd0019d1.acme.com#-O443 - broker 0: purpose doesn't match cluster:admin
bgd0017d1.acme.com#-O444 - broker 0: purpose doesn't match cluster:admin
bgd0004d1.acme.com#-O445 - broker 0: purpose doesn't match cluster:admin
2015-08-01 08:10:51,388 [Thread-69] INFO  ly.stealth.mesos.kafka.Scheduler$  - [statusUpdate] broker-0-0e042dac-a4ff-474e-9909-44aa2229c84b TASK_ERROR slave:#34-S4 reason:REASON_TASK_INVALID message:Task uses more resources cpus(*):5; mem(*):6000; ports(*):[9092-9092] than available ports(*):[4000-32000]; disk(*):1.84383e+06; cpus(kafka):32; mem(kafka):515816
2015-08-01 08:10:51,389 [Thread-69] INFO  ly.stealth.mesos.kafka.Scheduler$  - Broker 0 failed 1, waiting 1m, next start ~ 2015-08-01 08:11:51Z
```

After my patch:

```
2015-08-01 10:13:50,822 [Thread-65] INFO  ly.stealth.mesos.kafka.Scheduler$  - Starting broker 0: launching task broker-0-749ed59b-b7b8-4537-9d55-a658f1ac9538 by offer bgd0001d1.acme.com#15642
 broker-0-749ed59b-b7b8-4537-9d55-a658f1ac9538 slave:#34-S3 cpus:5.00 mem:6000.00 ports:[9092..9092] data:defaults=broker.id\=0\,log.dirs\=kafka-logs\,port\=9092\,zookeeper.connect\=###.###.66.12:2181\\\,###.###.66.17:2181\\\,###.###.66.23:2181\,host.name\=bgd0001d1.acme.com\,log.retention.bytes\=10737418240,broker={"stickiness" : {"period" : "24h"\, "stopTime" : "2015-08-01 08:16:09.067"}\, "bindAddress" : "if:eth4"\, "options" : "log.flush.interval.ms\=10000\,delete.topic.enable\=true\,num.network.threads\=8\,offsets.storage\=kafka\,log.dirs\=\\/a\\/kafka\\/0\\/kafka-logs\,num.replica.fetchers\=4\,num.io.threads\=8\,auto.create.topics.enable\=false"\, "id" : "0"\, "port" : "9092"\, "constraints" : "purpose\=cluster:admin"\, "mem" : 6000\, "jvmOptions" : "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port\=9990 -Dcom.sun.management.jmxremote.local.only\=false -Dcom.sun.management.jmxremote.authenticate\=false -Dcom.sun.management.jmxremote.ssl\=false"\, "cpus" : 5.0\, "heap" : 4000\, "failover" : {"delay" : "1m"\, "maxDelay" : "10m"}\, "active" : true}
2015-08-01 10:13:50,824 [Thread-65] INFO  ly.stealth.mesos.kafka.Scheduler$  - Declined offers:
bgd0004d1.acme.com#15640 - broker 0: purpose doesn't match cluster:admin
bgd0010d1.acme.com#15641 - broker 0: purpose doesn't match cluster:admin
2015-08-01 10:14:03,469 [Thread-69] INFO  ly.stealth.mesos.kafka.Scheduler$  - [statusUpdate] broker-0-749ed59b-b7b8-4537-9d55-a658f1ac9538 TASK_RUNNING slave:#34-S3 data: ###.###.66.11:9092
2015-08-01 10:14:13,521 [Thread-71] INFO  ly.stealth.mesos.kafka.Scheduler$  - [resourceOffers]
bgd0004d1.acme.com#15673 cpus:32.00 mem:515816.00 disk:1843834.00 ports:[4000..32000] purpose:compute;storagemedia:magnetic
bgd0002d1.acme.com#15674 cpus:32.00 mem:515816.00 disk:1843834.00 ports:[4000..32000] purpose:admin;storagemedia:magnetic
bgd0016d1.acme.com#15675 cpus:32.00 mem:257273.00 disk:1843834.00 ports:[4000..32000] purpose:compute;storagemedia:ssd
bgd0005d1.acme.com#15676 cpus:31.90 mem:513768.00 disk:1843834.00 ports:[4000..6999][7001..32000] purpose:compute;storagemedia:magnetic
bgd0017d1.acme.com#15677 cpus:32.00 mem:257273.00 disk:1843834.00 ports:[4000..32000] purpose:compute;storagemedia:ssd
bgd0018d1.acme.com#15678 cpus:32.00 mem:257273.00 disk:1843834.00 ports:[4000..32000] purpose:compute;storagemedia:ssd
bgd0010d1.acme.com#15679 cpus:31.90 mem:515560.00 disk:1843834.00 ports:[4000..9999][10001..32000] purpose:compute;storagemedia:magnetic
bgd0006d1.acme.com#15680 cpus:32.00 mem:515816.00 disk:1843834.00 ports:[4000..32000] purpose:admin;storagemedia:magnetic
bgd0012d1.acme.com#15681 cpus:32.00 mem:515816.00 disk:1843834.00 ports:[4000..32000] purpose:compute;storagemedia:ssd
bgd0007d1.acme.com#15682 cpus:32.00 mem:515816.00 disk:1843834.00 ports:[4000..32000] purpose:admin;storagemedia:magnetic
-----
2015-08-01 10:14:13,523 [Thread-71] INFO  ly.stealth.mesos.kafka.Scheduler$  - Declined offers for no provided reason. (Probably because all brokers already running)
2015-08-01 10:14:23,559 [Thread-73] INFO  ly.stealth.mesos.kafka.Scheduler$  - [resourceOffers]
bgd0001d1.acme.com#15691 cpus:27.00 mem:509816.00 disk:1843834.00 ports:[4000..9091][9093..32000] purpose:admin;storagemedia:magnetic
2015-08-01 10:14:23,560 [Thread-73] INFO  ly.stealth.mesos.kafka.Scheduler$  - Declined offers for no provided reason. (Probably because all brokers already running)
2015-08-01 10:14:33,597 [Thread-75] INFO  ly.stealth.mesos.kafka.Scheduler$  - [statusUpdate] broker-0-749ed59b-b7b8-4537-9d55-a658f1ac9538 TASK_RUNNING slave:#34-S3 data: ###.###.66.11:9092
```
