### PR TITLE
broker_attr_matching_distr

### DIFF
--- a/kafka-mesos.properties
+++ b/kafka-mesos.properties
@@ -5,7 +5,7 @@ user=vagrant
 
 storage=file:kafka-mesos.json
 
-master=zk://master:2181/mesos
+master=master:5050
 
 zk=master:2181
 

--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -459,7 +459,7 @@ object HttpServer {
       val brokerExpr: String = if (request.getParameter("broker") != null) request.getParameter("broker") else "*"
       var brokers: util.List[String] = null
       if (brokerExpr != null)
-        try { brokers = Expr.expandBrokers(cluster, brokerExpr) }
+        try { brokers = Expr.expandBrokers(cluster, brokerExpr, sortByAttrs = true) }
         catch { case e: IllegalArgumentException => response.sendError(400, "invalid broker-expr"); return }
 
       var timeout: Period = new Period("0")

--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -400,7 +400,7 @@ object HttpServer {
       
       var brokerIds: util.List[Int] = null
       if (request.getParameter("broker") != null)
-        try { brokerIds = Expr.expandBrokers(Scheduler.cluster, request.getParameter("broker")).map(Integer.parseInt) }
+        try { brokerIds = Expr.expandBrokers(Scheduler.cluster, request.getParameter("broker"), sortByAttrs = true).map(Integer.parseInt) }
         catch { case e: IllegalArgumentException => errors.add("Invalid broker-expr") }
 
       var partitions: Int = 1

--- a/src/scala/ly/stealth/mesos/kafka/Rebalancer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Rebalancer.scala
@@ -114,7 +114,7 @@ class Rebalancer {
       val rf: Int = if (replicas != -1) replicas else entry._2.valuesIterator.next().size
       val partitions: Int = entry._2.size
     
-      val assignedReplicas: Map[Int, Seq[Int]] = AdminUtils.assignReplicasToBrokers(brokerIds, partitions, rf)
+      val assignedReplicas: Map[Int, Seq[Int]] = AdminUtils.assignReplicasToBrokers(brokerIds, partitions, rf, 0, 0)
       reassignment ++= assignedReplicas.map(replicaEntry => TopicAndPartition(topic, replicaEntry._1) -> replicaEntry._2)
     }
 


### PR DESCRIPTION
Hey,

Following changes were added:
- if specified topic add|rebalance --broker param with attrs (i.e. *[rack]), it now sorts broker list by specified attr value;
- rebalance now uses initial offset and partition id (previously was random value), so it would produce same result for sequential runs;

As a consequence, it should distribute correctly partitions of newly created or rebalanced topic taking into account actual attribute value. For instance, if we have 5 brokers in 3 racks and creating a topic with 3 partitions it will select brokers with different rack values. On the other hand, if the number of partitions is larger than brokers count the behavior would be +/- the same as before (we should use all available brokers in that case).

Please review & merge.
