### PR TITLE
Fix NPEs in SchedulerTest

### DIFF
--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -92,7 +92,7 @@ object HttpServer {
     if (jar == null) throw new IllegalStateException(jarMask + " not found in current dir")
     if (kafkaDist == null) throw new IllegalStateException(kafkaMask + " not found in in current dir")
 
-    // extract version
+    // extract version: "kafka-dist-1.2.3.tgz" => "1.2.3"
     val distName: String = kafkaDist.getName
     val tgzIdx = distName.lastIndexOf(".tgz")
     val hIdx = distName.lastIndexOf("-")

--- a/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
+++ b/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
@@ -83,6 +83,7 @@ class MesosTestCase {
 
     HttpServer.jar = createTempFile("executor.jar", "executor")
     HttpServer.kafkaDist = createTempFile("kafka-0.9.3.0.tgz", "kafka")
+    HttpServer.kafkaVersion = new Util.Version("0.9.3.0")
   }
 
   @After


### PR DESCRIPTION
HttpServer.kafkaVersion is being accessed before HttpServer.start() is called

ly.stealth.mesos.kafka.SchedulerTest > syncBrokers FAILED
    java.lang.NullPointerException at SchedulerTest.scala:88

ly.stealth.mesos.kafka.SchedulerTest > launchTask FAILED
    java.lang.NullPointerException at SchedulerTest.scala:182

ly.stealth.mesos.kafka.SchedulerTest > acceptOffer FAILED
    java.lang.NullPointerException at SchedulerTest.scala:112

ly.stealth.mesos.kafka.SchedulerTest > newTask FAILED
    java.lang.NullPointerException at SchedulerTest.scala:54
