### PR TITLE
Basic broker metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ For issues https://github.com/mesos/kafka/issues
 * [High Availability Scheduler State](#high-availability-scheduler-state)
 * [Failed Broker Recovery](#failed-broker-recovery)
 * [Passing multiple options](#passing-multiple-options)
+* [Broker metrics](#broker-metrics)
 
 
 [Navigating the CLI](#navigating-the-cli)
@@ -316,6 +317,49 @@ broker updated:
   options: log.dirs=/mnt/array1/broker0\,/mnt/array2/broker0,num.io.threads=16
   failover: delay:1m, max-delay:10m
   stickiness: period:10m, hostname:slave0, expires:2015-07-29 11:54:39Z
+```
+
+Broker metrics
+--------------
+Executor sends broker metrics to scheduler every 5 seconds, such as:
+- under-replicated-partitions is number of under replicated partitions (| ISR | < | all replicas |)
+- offline-partitions-count is number of partitions that don't have an active leader and are hence not writable or readable
+- active-controller-count is number of active controllers in the cluster, only one broker in cluster should have value "1"
+
+```
+./kafka-mesos.sh broker list
+brokers:
+  id: 0
+  active: true
+  state: running
+  resources: cpus:1.00, mem:2048, heap:1024, port:auto
+  failover: delay:1m, max-delay:10m
+  stickiness: period:10m, hostname:slave0
+  task:
+    id: broker-0-826e8075-5dd3-49ab-b86e-6432fa03ef66
+    state: running
+    endpoint: slave0:9092 (slave0)
+  metrics:
+    collected: 2016-01-18 11:53:36Z
+    under-replicated-partitions: 0
+    offline-partitions-count: 0
+    active-controller-count: 1
+
+  id: 1
+  active: true
+  state: running
+  resources: cpus:1.00, mem:2048, heap:1024, port:auto
+  failover: delay:1m, max-delay:10m
+  stickiness: period:10m, hostname:slave1
+  task:
+    id: broker-1-4648130a-9aa0-4c7e-b8af-761c03aa111c
+    state: running
+    endpoint: slave1:9092 (slave1)
+  metrics:
+    collected: 2016-01-18 11:53:36Z
+    under-replicated-partitions: 0
+    offline-partitions-count: 0
+    active-controller-count: 0
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ broker updated:
 
 Broker metrics
 --------------
-Executor sends broker metrics to scheduler every 5 seconds, such as:
+Executor sends broker metrics to scheduler every 30 seconds, such as:
 - under-replicated-partitions is number of under replicated partitions (| ISR | < | all replicas |)
 - offline-partitions-count is number of partitions that don't have an active leader and are hence not writable or readable
 - active-controller-count is number of active controllers in the cluster, only one broker in cluster should have value "1"

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Broker metrics
 Executor sends broker metrics to scheduler every 30 seconds, such as:
 - under-replicated-partitions is number of under replicated partitions (| ISR | < | all replicas |)
 - offline-partitions-count is number of partitions that don't have an active leader and are hence not writable or readable
-- active-controller-count is number of active controllers in the cluster, only one broker in cluster should have value "1"
+- is-active-controller is controller active on broker, only one broker in cluster should have value "1"
 
 ```
 ./kafka-mesos.sh broker list
@@ -343,7 +343,7 @@ brokers:
     collected: 2016-01-18 11:53:36Z
     under-replicated-partitions: 0
     offline-partitions-count: 0
-    active-controller-count: 1
+    is-active-controller: 1
 
   id: 1
   active: true
@@ -359,7 +359,7 @@ brokers:
     collected: 2016-01-18 11:53:36Z
     under-replicated-partitions: 0
     offline-partitions-count: 0
-    active-controller-count: 0
+    is-active-controller: 0
 ```
 
 

--- a/src/scala/ly/stealth/mesos/kafka/BrokerServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/BrokerServer.scala
@@ -219,7 +219,7 @@ object BrokerServer {
       attribute[T](server, objName, "Value")
     }
 
-    def collect: Option[Broker.Metrics] = {
+    def collect: Broker.Metrics = {
       val servers = MBeanServerFactory.findMBeanServer(null).asScala.toList
       servers.find(s => s.getDomains.exists(_.equals("kafka.server"))).map { server: MBeanServer =>
         val metrics: Broker.Metrics = new Broker.Metrics()
@@ -231,7 +231,7 @@ object BrokerServer {
         metrics.timestamp = System.currentTimeMillis()
 
         metrics
-      }
+      }.getOrElse(null)
     }
   }
 }

--- a/src/scala/ly/stealth/mesos/kafka/Cli.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cli.scala
@@ -681,7 +681,7 @@ object Cli {
         printLine("collected: " + Str.dateTime(new Date(metrics.timestamp)), indent + 1)
         printLine("under-replicated-partitions: " + metrics.underReplicatedPartitions, indent + 1)
         printLine("offline-partitions-count: " + metrics.offlinePartitionsCount, indent + 1)
-        printLine("active-controller-count: " + metrics.activeControllerCount, indent + 1)
+        printLine("is-active-controller: " + metrics.activeControllerCount, indent + 1)
       }
     }
     

--- a/src/scala/ly/stealth/mesos/kafka/Cli.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cli.scala
@@ -23,7 +23,7 @@ import scala.io.Source
 import java.io._
 import java.util
 import scala.collection.JavaConversions._
-import java.util.{Properties, Collections}
+import java.util.{Date, Properties, Collections}
 import ly.stealth.mesos.kafka.Util.{BindAddress, Str, Period}
 import ly.stealth.mesos.kafka.Topics.Topic
 
@@ -673,6 +673,15 @@ object Cli {
         printLine("state: " + task.state, indent + 1)
         if (task.endpoint != null) printLine("endpoint: " + task.endpoint + (if (broker.bindAddress != null) " (" + task.hostname + ")" else ""), indent + 1)
         if (!task.attributes.isEmpty) printLine("attributes: " + Util.formatMap(task.attributes), indent + 1)
+      }
+
+      val metrics = broker.metrics
+      if (metrics != null) {
+        printLine("metrics: ", indent)
+        printLine("collected: " + Str.dateTime(new Date(metrics.timestamp)), indent + 1)
+        printLine("under-replicated-partitions: " + metrics.underReplicatedPartitions, indent + 1)
+        printLine("offline-partitions-count: " + metrics.offlinePartitionsCount, indent + 1)
+        printLine("active-controller-count: " + metrics.activeControllerCount, indent + 1)
       }
     }
     

--- a/src/scala/ly/stealth/mesos/kafka/Util.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Util.scala
@@ -29,7 +29,13 @@ import java.net.{Inet4Address, InetAddress, NetworkInterface}
 
 object Util {
   Class.forName(kafka.utils.Json.getClass.getName) // init class
-  private def parseNumber(s: String): Number = if (s.contains(".")) s.toDouble else s.toInt
+  private def parseNumber(s: String): Number =
+    if (s.contains(".")) {
+      s.toDouble
+    } else {
+      try { java.lang.Integer.parseInt(s) }
+      catch { case e: java.lang.NumberFormatException => s.toLong }
+    }
 
   JSON.globalNumberParser = parseNumber
   JSON.perThreadNumberParser = parseNumber

--- a/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
+++ b/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
@@ -31,7 +31,6 @@ import org.apache.log4j.BasicConfigurator
 import java.io.{FileWriter, File}
 import com.google.protobuf.ByteString
 import java.util.concurrent.atomic.AtomicBoolean
-import scala.util.parsing.json.JSON
 import ly.stealth.mesos.kafka.Cluster.FsStorage
 import org.I0Itec.zkclient.{ZkClient, IDefaultNameSpace, ZkServer}
 import java.net.ServerSocket
@@ -46,9 +45,6 @@ class MesosTestCase {
 
   @Before
   def before {
-    def parseNumber(s: String): Number = if (s.contains(".")) s.toDouble else s.toInt
-    JSON.globalNumberParser = parseNumber
-    JSON.perThreadNumberParser = parseNumber
 
     BasicConfigurator.configure()
 

--- a/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
+++ b/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
@@ -153,6 +153,8 @@ class MesosTestCase {
   val LOCALHOST_IP: Int = 2130706433
   
   def frameworkId(id: String = "" + UUID.randomUUID()): FrameworkID = FrameworkID.newBuilder().setValue(id).build()
+  def executorId(id: String = "" + UUID.randomUUID()): ExecutorID = ExecutorID.newBuilder().setValue(id).build()
+  def slaveId(id: String = "" + UUID.randomUUID()): SlaveID = SlaveID.newBuilder().setValue(id).build()
   def taskId(id: String = "" + UUID.randomUUID()): TaskID = TaskID.newBuilder().setValue(id).build()
 
   def master(


### PR DESCRIPTION
Motivation:
Metrics are useful and important information for monitoring broker.
Important metrics: 

> 1 kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions
> number of under-replicated partitions (| ISR | < | all replicas |) (dangerous when 0).
> 2 kafka.controller:type=KafkaController,name=OfflinePartitionsCount
> number of partitions that don't have an active leader and are hence not writable or readable (dangerous when 0).
> 3 kafka.controller:type=KafkaController,name=ActiveControllerCount
> number of active controllers in the cluster. (dangerous when value is anything other than 1).

for more information on metrics see http://docs.confluent.io/1.0/kafka/monitoring.html

Changes:
- executor: executor start to pull metrics every 5 seconds (right after broker start)
  through JMX and send them to scheduler via sendFrameworkMessage
- scheduler: scheduler receives servialized JSON metrics and updates
  corresponding active broker
- cli: metrics are shown in output of `broker list`, for example:

```
./kafka-mesos.sh broker list
brokers:
  id: 0
  active: true
  state: running
  ...
  metrics:
    collected: 2016-01-18 11:53:36Z
    under-replicated-partitions: 0
    offline-partitions-count: 0
    active-controller-count: 1

  id: 1
  active: true
  state: running
  ...
  metrics:
    collected: 2016-01-18 11:53:36Z
    under-replicated-partitions: 0
    offline-partitions-count: 0
    active-controller-count: 0
```
