### PR TITLE
Allow retrieving broker logs via the api 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For issues https://github.com/mesos/kafka/issues
 * [Run the scheduler on Marathon](https://github.com/mesos/kafka/tree/master/src/docker#running-image-in-marathon)  
 * [Changing the location where data is stored](#changing-the-location-where-data-is-stored)
 * [Starting 3 brokers](#starting-3-brokers)
+* [View broker log](#view-broker-log)
 * [High Availability Scheduler State](#high-availability-scheduler-state)
 * [Failed Broker Recovery](#failed-broker-recovery)
 * [Passing multiple options](#passing-multiple-options)
@@ -26,6 +27,7 @@ For issues https://github.com/mesos/kafka/issues
 * [Starting brokers](#starting-brokers-in-the-cluster)
 * [Stopping brokers](#stopping-brokers-in-the-cluster)
 * [Removing brokers](#removing-brokers-from-the-cluster)
+* [Retrieving broker log](#retrieving-broker-log)
 * [Rebalancing brokers in the cluster](#rebalancing-topics)
 * [Listing topics](#listing-topics)
 * [Adding topic](#adding-topic)
@@ -269,6 +271,35 @@ brokers started:
   state: running
   ...
 ```
+
+View broker log
+---------------
+
+Strings are always being read from the end of a file.
+Get last 100 lines from `stdout` file of broker 0,
+```
+./kafka-mesos.sh broker log 0
+```
+
+or from `stderr`
+
+```
+./kafka-mesos.sh broker log 0 --name stderr
+```
+
+or any file in kafka-*/log/, for example: `server.log`
+
+```
+./kafka-mesos.sh broker log 0 --name server.log
+```
+
+or maybe more lines
+
+```
+./kafka-mesos.sh broker log 0 --name server.log --lines 200
+```
+
+current limit is 100Kb no matter how many lines being requested.
 
 High Availability Scheduler State
 -------------------------
@@ -562,6 +593,27 @@ attribute filtering:
   *[rack=r1]           - any broker having rack=r1
   *[hostname=slave*]   - any broker on host with name starting with 'slave'
   0..4[rack=r1,dc=dc1] - any broker having rack=r1 and dc=dc1
+```
+
+Retrieving broker log
+---------------------
+
+```
+Retrieve broker log
+Usage: broker log <broker-id> [options]
+
+Option             Description
+------             -----------
+--lines <Integer>  maximum number of lines to read from the end of file.
+                     Default - 100
+--name             name of log file (stdout, stderr, server.log). Default
+                     - stdout
+--timeout          timeout (30s, 1m, 1h). Default - 30s
+
+Generic Options
+Option  Description
+------  -----------
+--api   Api url. Example: http://master:7000
 ```
 
 Listing Topics

--- a/src/scala/ly/stealth/mesos/kafka/Message.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Message.scala
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ly.stealth.mesos.kafka
+
+import scala.util.parsing.json.JSONObject
+
+class Message {  }
+
+case class LogRequest(requestId: Long, lines: Int, name: String) {
+  override def toString: String = s"log,$requestId,$lines,$name"
+}
+
+object LogRequest {
+  def parse(message: String): LogRequest = {
+    val Array(_, rid, numLines, name) = message.split(",")
+    val requestId = rid.toLong
+    val lines = numLines.toInt
+
+    LogRequest(requestId, lines, name)
+  }
+}
+
+case class LogResponse(requestId: Long, content: String) {
+  def toJson: JSONObject =
+    scala.util.parsing.json.JSONObject(Map("log" -> JSONObject(Map("content" -> content, "requestId" -> requestId))))
+}
+
+object LogResponse {
+  def fromJson(node: Map[String, Object]): LogResponse = {
+    val logNode = node("log").asInstanceOf[Map[String, Any]]
+    val requestId = logNode("requestId").asInstanceOf[Long]
+    val content = logNode("content").asInstanceOf[String]
+    LogResponse(requestId, content)
+  }
+}

--- a/src/scala/ly/stealth/mesos/kafka/Util.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Util.scala
@@ -482,4 +482,53 @@ object Util {
       s.substring(s.length - maxLen)
     }
   }
+
+  def readLastLines(file: File, n: Int, maxBytes: Int = 102400): String = {
+    require(n > 0)
+
+    val raf = new java.io.RandomAccessFile(file, "r")
+    val fileLength: Long = raf.length()
+    var line = 0
+    var pos: Long = fileLength - 1
+    var found = false
+    var nlPos = pos
+
+    try {
+      while (pos != -1 && !found) {
+        raf.seek(pos)
+
+        if (raf.readByte() == 10) {
+          if (pos != fileLength - 1) {
+            line += 1
+          }
+          nlPos = pos
+        }
+
+        if (line == n) found = true
+        if (fileLength - pos > maxBytes) found = true
+
+        if (!found) pos -= 1
+      }
+
+      if (pos == -1) pos = 0
+
+      if (line == n) {
+        pos = pos + 1
+      } else if (fileLength - pos > maxBytes) {
+        pos = nlPos + 1
+      }
+
+      raf.seek(pos)
+
+      val buffer = new Array[Byte]((fileLength - pos).toInt)
+
+      raf.read(buffer, 0, buffer.length)
+
+      val str = new String(buffer, "UTF-8")
+
+      str
+    } finally {
+      raf.close()
+    }
+  }
 }

--- a/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
+++ b/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
@@ -336,6 +336,8 @@ class MesosTestCase {
     val killedTasks: util.List[String] = new util.ArrayList[String]()
     val reconciledTasks: util.List[String] = new util.ArrayList[String]()
 
+    val sentFrameworkMessages = new util.ArrayList[(ExecutorID, SlaveID, String)]()
+
     def declineOffer(id: OfferID): Status = {
       declinedOffers.add(id.getValue)
       status
@@ -381,7 +383,10 @@ class MesosTestCase {
 
     def requestResources(requests: util.Collection[Request]): Status = throw new UnsupportedOperationException
 
-    def sendFrameworkMessage(executorId: ExecutorID, slaveId: SlaveID, data: Array[Byte]): Status = throw new UnsupportedOperationException
+    def sendFrameworkMessage(executorId: ExecutorID, slaveId: SlaveID, data: Array[Byte]): Status = {
+      sentFrameworkMessages.add((executorId, slaveId, new String(data)))
+      status
+    }
 
     def join(): Status = throw new UnsupportedOperationException
 


### PR DESCRIPTION
MOTIVATION: 
Having a way to get some of the broker logs for verification and debugging.
It is meant to give user last N lines of a log file, thus isn't a live streaming realtime log tool. 

PROPOSED CHANGE:
Adding new CLI command `broker log`, which will output last N lines.

```
Retrieve broker log
Usage: broker log <broker-id> [options]

Option             Description
------             -----------
--lines <Integer>  maximum number of lines to read from the end of file.
                     Default - 100
--name             name of log file (stdout, stderr, server.log). Default
                     - stdout
```

name option could be stdout, stderr this are the special case, any other file will
be searched in kafka-*/log/ directory (examples: server.log, controller.log, kafka-authorizer.log, kafka-request.log, 
log-cleaner.log, server.log, state-change.log, ...). 

Current limit is 100Kb no matter how many lines being requested, intended 
to avoid overloading executor and scheduler.

original idea https://github.com/mesos/kafka/issues/143#issuecomment-155081454

USAGE EXAMPLES:

Strings are always being read from the end of a file.
Get last 100 lines from `stdout` file of broker 0,

```
./kafka-mesos.sh broker log 0
```

or from `stderr`

```
./kafka-mesos.sh broker log 0 --name stderr
```

or any file in kafka-*/log/, for example: `server.log`

```
./kafka-mesos.sh broker log 0 --name server.log
```

or maybe more lines

```
./kafka-mesos.sh broker log 0 --name server.log --lines 200
```

HTTP API:
adding call POST /broker/log
parameters are same as for CLI options e.g. name, lines

Output format:

```
{
    "status": <"timeout" | "ok">,
    "content": <content of log>
}
```

Communication between scheduler and executor are via framework messages.
