### PR TITLE
Rolling restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For issues https://github.com/mesos/kafka/issues
 * [Failed Broker Recovery](#failed-broker-recovery)
 * [Passing multiple options](#passing-multiple-options)
 * [Broker metrics](#broker-metrics)
+* [Rolling restart](#rolling-restart)
 
 
 [Navigating the CLI](#navigating-the-cli)
@@ -26,6 +27,7 @@ For issues https://github.com/mesos/kafka/issues
 * [Updating broker configurations](#updating-broker-configurations)
 * [Starting brokers](#starting-brokers-in-the-cluster)
 * [Stopping brokers](#stopping-brokers-in-the-cluster)
+* [Restarting brokers](#restarting-brokers-in-the-cluster)
 * [Removing brokers](#removing-brokers-from-the-cluster)
 * [Retrieving broker log](#retrieving-broker-log)
 * [Rebalancing brokers in the cluster](#rebalancing-topics)
@@ -393,6 +395,128 @@ brokers:
     is-active-controller: 0
 ```
 
+Rolling restart
+---------------
+
+For example there are 3 running brokers and you want to add new log dir /mnt/array2/broker$id alongside
+already used /mnt/array1/broker$id
+
+```
+# ./kafka-mesos.sh broker list
+brokers:
+  id: 0
+  active: true
+  state: running
+  resources: cpus:0.50, mem:2048, heap:1024, port:9092
+  bind-address: slave0
+  constraints: hostname=like:slave0
+  options: log.dirs=/mnt/array1/broker$id
+  ...
+
+  id: 1
+  active: true
+  state: running
+  resources: cpus:0.50, mem:2048, heap:1024, port:9092
+  bind-address: slave1
+  constraints: hostname=like:slave1
+  options: log.dirs=/mnt/array1/broker$id
+  ...
+
+  id: 2
+  active: true
+  state: running
+  resources: cpus:0.50, mem:2048, heap:1024, port:9092
+  bind-address: slave2
+  constraints: hostname=like:slave2
+  options: log.dirs=/mnt/array1/broker$id
+  ...
+```
+
+Update brokers by adding new log dir (they were already using dir /mnt/array1/broker$id).
+
+NOTE: you could update brokers in running state, however configuration updated only in
+scheduler, thus you need to restart brokers to apply changes. Whenever you update running
+broker `broker list` will show you notification `(modified, needs restart)` right in state description,
+notice will disappear once broker restarted.
+
+```
+# ./kafka-mesos.sh broker update 1..3 --options log.dirs=/mnt/array1/broker\$id\\,/mnt/array2/broker\$id
+brokers updated:
+  id: 0
+  active: true
+  state: running (modified, needs restart)
+  resources: cpus:0.50, mem:2048, heap:1024, port:9092
+  bind-address: slave0
+  constraints: hostname=like:slave0
+  options: log.dirs=/mnt/array1/broker$id\,/mnt/array2/broker$id
+  ...
+
+  id: 1
+  active: true
+  state: running (modified, needs restart)
+  resources: cpus:0.50, mem:2048, heap:1024, port:9092
+  bind-address: slave1
+  constraints: hostname=like:slave1
+  options: log.dirs=/mnt/array1/broker$id\,/mnt/array2/broker$id
+  ...
+
+  id: 2
+  active: true
+  state: running (modified, needs restart)
+  resources: cpus:0.50, mem:2048, heap:1024, port:9092
+  bind-address: slave2
+  constraints: hostname=like:slave2
+  options: log.dirs=/mnt/array1/broker$id\,/mnt/array2/broker$id
+  ...
+```
+
+Rolling restart (sequentially stop then start each broker) gives you ability to combine
+`stop` then `start` for each broker in single action. See [restart CLI options](#restarting-brokers-in-the-cluster).
+
+```
+# ./kafka-mesos.sh broker restart 1..3 --timeout 5m
+brokers restarted:
+  id: 0
+  active: true
+  state: running
+  resources: cpus:0.50, mem:2048, heap:1024, port:9092
+  bind-address: slave0
+  constraints: hostname=like:slave0
+  options: log.dirs=/mnt/array1/broker$id\,/mnt/array2/broker$id
+  ...
+
+  id: 1
+  active: true
+  state: running
+  resources: cpus:0.50, mem:2048, heap:1024, port:9092
+  bind-address: slave1
+  constraints: hostname=like:slave1
+  options: log.dirs=/mnt/array1/broker$id\,/mnt/array2/broker$id
+  ...
+
+  id: 2
+  active: true
+  state: running
+  resources: cpus:0.50, mem:2048, heap:1024, port:9092
+  bind-address: slave2
+  constraints: hostname=like:slave2
+  options: log.dirs=/mnt/array1/broker$id\,/mnt/array2/broker$id
+  ...
+```
+
+It's possible that some broker could timeout on `stop` or `start`, in such case `restart` halts with notice:
+
+```
+# ./kafka-mesos.sh broker restart 1..3 --timeout 5m
+Error: broker 1 timeout on stop
+```
+
+or for `start`
+
+```
+# ./kafka-mesos.sh broker restart 1..3 --timeout 5m
+Error: broker 1 timeout on start
+```
 
 Navigating the CLI
 ==================
@@ -552,6 +676,35 @@ Option     Description
 ------     -----------
 --force    forcibly stop
 --timeout  timeout (30s, 1m, 1h). 0s - no timeout
+
+Generic Options
+Option  Description
+------  -----------
+--api   Api url. Example: http://master:7000
+
+broker-expr examples:
+  0      - broker 0
+  0,1    - brokers 0,1
+  0..2   - brokers 0,1,2
+  0,1..2 - brokers 0,1,2
+  *      - any broker
+attribute filtering:
+  *[rack=r1]           - any broker having rack=r1
+  *[hostname=slave*]   - any broker on host with name starting with 'slave'
+  0..4[rack=r1,dc=dc1] - any broker having rack=r1 and dc=dc1
+```
+
+Restarting brokers in the cluster
+---------------------------------
+
+```
+# ./kafka-mesos.sh help broker restart
+Restart broker
+Usage: broker restart <broker-expr> [options]
+
+Option     Description
+------     -----------
+--timeout  time to wait until broker restarts (30s, 1m, 1h). Default - 2m
 
 Generic Options
 Option  Description
@@ -768,6 +921,12 @@ Stopping a broker
 {"success" : true, "ids" : "0"}
 ```
 
+Restarting a broker
+
+```
+# curl "http://localhost:7000/api/broker/restart?broker=0"
+{"status" : "restarted", "brokers" : [{"task" : {"hostname" : "slave0", "state" : "running", "slaveId" : "fd935975-5db0-4732-bfa4-3063b534972d-S3", "executorId" : "broker-0-a8e0d084-b890-4482-800e-12e72ed7f9ed", "attributes" : {}, "id" : "broker-0-ff11db36-206a-4019-9cd2-6993376831eb", "endpoint" : "slave0:9092"}, "stickiness" : {"period" : "10m", "hostname" : "slave0"}, "bindAddress" : "slave0", "options" : "log.dirs=\/tmp\/kafka\/$id", "id" : "2", "port" : "9092", "constraints" : "hostname=like:slave0", "mem" : 1024, "cpus" : 0.5, "metrics" : {"underReplicatedPartitions" : 0, "offlinePartitionsCount" : 0, "activeControllerCount" : 0, "timestamp" : 1455557472857}, "heap" : 1024, "failover" : {"delay" : "1m", "maxDelay" : "14m"}, "active" : true}]}
+```
 Removing a broker
 
 ```
@@ -801,8 +960,6 @@ Project Goals
 * preservation of broker placement (through constraints and/or new features).
 
 * ability to-do configuration changes.
-
-* rolling restarts (for things like configuration changes).
 
 * scaling the cluster up and down with automatic, programmatic and manual options.
 

--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -54,6 +54,9 @@ class Broker(_id: String = "0") {
 
   var metrics: Metrics = null
 
+  // broker has been modified while being in non stopped state, once stopped or before task launch becomes false
+  var needsRestart: Boolean = false
+
   def options(defaults: util.Map[String, String] = null): util.Map[String, String] = {
     val result = new util.LinkedHashMap[String, String]()
     if (defaults != null) result.putAll(defaults)
@@ -269,6 +272,8 @@ class Broker(_id: String = "0") {
       metrics = new Broker.Metrics()
       metrics.fromJson(node("metrics").asInstanceOf[Map[String, Object]])
     }
+
+    if (node.contains("needsRestart")) needsRestart = node("needsRestart").asInstanceOf[Boolean]
   }
 
   def toJson: JSONObject = {
@@ -292,6 +297,7 @@ class Broker(_id: String = "0") {
     obj("failover") = failover.toJson
     if (task != null) obj("task") = task.toJson
     if (metrics != null) obj("metrics") = metrics.toJson
+    if (needsRestart) obj("needsRestart") = needsRestart
 
     new JSONObject(obj.toMap)
   }

--- a/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
@@ -277,11 +277,14 @@ object Scheduler extends org.apache.mesos.Scheduler {
     }
 
     broker.metrics = null
+    broker.needsRestart = false
   }
 
   private def isReconciling: Boolean = cluster.getBrokers.exists(b => b.task != null && b.task.reconciling)
 
   private[kafka] def launchTask(broker: Broker, offer: Offer): Unit = {
+    broker.needsRestart = false
+
     val reservation = broker.getReservation(offer)
     val task_ = newTask(broker, offer, reservation)
     val id = task_.getTaskId.getValue

--- a/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
@@ -548,6 +548,8 @@ object BrokerTest {
 
     assertFailoverEquals(expected.failover, actual.failover)
     assertTaskEquals(expected.task, actual.task)
+
+    assertEquals(expected.needsRestart, actual.needsRestart)
   }
 
   def assertFailoverEquals(expected: Failover, actual: Failover) {

--- a/src/test/ly/stealth/mesos/kafka/HttpServerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/HttpServerTest.scala
@@ -17,14 +17,16 @@
 
 package ly.stealth.mesos.kafka
 
+import org.apache.mesos.Protos.TaskState
 import org.junit.{Test, After, Before}
 import org.junit.Assert._
-import java.io.{FileOutputStream, File}
+import java.io.{IOException, FileOutputStream, File}
 import java.net.{HttpURLConnection, URL}
 import Util.{Period, parseMap}
 import Cli.sendRequest
 import ly.stealth.mesos.kafka.Topics.Topic
 import java.util
+import scala.collection.JavaConversions._
 
 class HttpServerTest extends MesosTestCase {
   @Before
@@ -73,7 +75,7 @@ class HttpServerTest extends MesosTestCase {
   @Test
   def broker_update {
     sendRequest("/broker/add", parseMap("broker=0"))
-    val json = sendRequest("/broker/update", parseMap("broker=0,cpus=1,heap=128,failoverDelay=5s"))
+    var json = sendRequest("/broker/update", parseMap("broker=0,cpus=1,heap=128,failoverDelay=5s"))
     val brokerNodes = json("brokers").asInstanceOf[List[Map[String, Object]]]
 
     assertEquals(1, brokerNodes.size)
@@ -86,6 +88,34 @@ class HttpServerTest extends MesosTestCase {
     assertEquals(new Period("5s"), broker.failover.delay)
 
     BrokerTest.assertBrokerEquals(broker, responseBroker)
+
+    // needsRestart flag
+    assertFalse(broker.needsRestart)
+    // needsRestart is false despite update when broker stopped
+    json = sendRequest("/broker/update", parseMap("broker=0,mem=2048"))
+    assertFalse(broker.needsRestart)
+
+    // when broker starting
+    sendRequest("/broker/start", parseMap(s"broker=0,timeout=0s"))
+    sendRequest("/broker/update", parseMap("broker=0,mem=4096"))
+    assertTrue(broker.needsRestart)
+
+    // modification is made before offer thus when it arrives needsRestart reset to false
+    Scheduler.resourceOffers(schedulerDriver, Seq(offer(resources = "cpus:2.0;mem:8192;ports:9042..65000", hostname = "slave0")))
+    assertFalse(broker.needsRestart)
+
+    // when running
+    Scheduler.statusUpdate(schedulerDriver, taskStatus(id = broker.task.id, state = TaskState.TASK_RUNNING, data = "slave0:9042"))
+    assertEquals(Broker.State.RUNNING, broker.task.state)
+    sendRequest("/broker/update", parseMap("broker=0,log4jOptions=log4j.logger.kafka=DEBUG\\, kafkaAppender"))
+    assertTrue(broker.needsRestart)
+
+    // once stopped needsRestart flag reset to false
+    sendRequest("/broker/stop", parseMap("broker=0,timeout=0s"))
+    assertTrue(broker.needsRestart)
+    Scheduler.resourceOffers(schedulerDriver, Seq(offer(resources = "cpus:0.01;mem:128;ports:0..1")))
+    Scheduler.statusUpdate(schedulerDriver, taskStatus(id = Broker.nextTaskId(broker), state = TaskState.TASK_FINISHED))
+    assertFalse(broker.needsRestart)
   }
 
   @Test
@@ -149,6 +179,83 @@ class HttpServerTest extends MesosTestCase {
     assertEquals("scheduled", json("status"))
     assertFalse(broker0.active)
     assertFalse(broker1.active)
+  }
+
+  @Test(timeout = 5000)
+  def broker_restart: Unit = {
+    def assertErrorContains(params: String, str: String) =
+      try { sendRequest("/broker/restart", parseMap(params)); fail() }
+      catch { case e: IOException => assertTrue(e.getMessage.contains(str))}
+
+    assertErrorContains("broker=0,timeout=0s", "broker 0 not found")
+
+    val broker0 = Scheduler.cluster.addBroker(new Broker("0"))
+    val broker1 = Scheduler.cluster.addBroker(new Broker("1"))
+
+    assertErrorContains("broker=0,timeout=0s", "broker 0 is not running")
+
+    // two nodes
+    def started(broker: Broker) {
+      Scheduler.resourceOffers(schedulerDriver, Seq(offer(resources = "cpus:2.0;mem:2048;ports:9042..65000", hostname = "slave" + broker.id)))
+      Scheduler.statusUpdate(schedulerDriver, taskStatus(id = broker.task.id, state = TaskState.TASK_RUNNING, data = "slave" + broker.id + ":9042"))
+      assertEquals(Broker.State.RUNNING, broker.task.state)
+    }
+
+    def stopped(broker: Broker): Unit = {
+      Scheduler.resourceOffers(schedulerDriver, Seq(offer(resources = "cpus:0.01;mem:128;ports:0..1")))
+      Scheduler.statusUpdate(schedulerDriver, taskStatus(id = Broker.nextTaskId(broker), state = TaskState.TASK_FINISHED))
+      assertFalse(broker.active)
+      assertNull(broker.task)
+    }
+
+    def start(broker: Broker) = sendRequest("/broker/start", parseMap(s"broker=${broker.id},timeout=0s"))
+    def stop(broker: Broker) = sendRequest("/broker/stop", parseMap(s"broker=${broker.id},timeout=0s"))
+    def restart(params: String): Map[String, Object] = sendRequest("/broker/restart", parseMap(params))
+
+    start(broker0); started(broker0); start(broker1); started(broker1)
+
+    // 0 stop timeout
+    var json = restart("broker=*,timeout=300ms")
+    assertEquals(Map("status" -> "timeout", "message" -> "broker 0 timeout on stop"), json)
+
+    stopped(broker0); start(broker0); started(broker0)
+
+    // 0 start timeout
+    delay("150ms") { stopped(broker0) }
+    json = restart("broker=*,timeout=300ms")
+    assertEquals(Map("status" -> "timeout", "message" -> "broker 0 timeout on start"), json)
+
+    started(broker0)
+
+    // 0 start, but 1 isn't running
+    delay("150ms") { stopped(broker0) }
+    delay("175ms") { stop(broker1); stopped(broker1) }
+    delay("300ms") { started(broker0) }
+    assertErrorContains("broker=*,timeout=500ms", "broker 1 is not running")
+
+    start(broker1); started(broker1)
+
+    // 1 stop timeout
+    delay("150ms") { stopped(broker0) }
+    delay("250ms") { started(broker0) }
+    json = restart("broker=*,timeout=400ms")
+    assertEquals(Map("status" -> "timeout", "message" -> "broker 1 timeout on stop"), json)
+
+    stopped(broker1); start(broker1); started(broker1)
+
+    // restarted
+    delay("150ms") { stopped(broker0) }
+    delay("250ms") { started(broker0) }
+    delay("350ms") { stopped(broker1) }
+    delay("450ms") { started(broker1) }
+    json = restart("broker=*,timeout=1s")
+
+    assertEquals(json("status"), "restarted")
+    for((brokerJson, expectedBroker) <- json("brokers").asInstanceOf[List[Map[String, Object]]].zip(Seq(broker0, broker1))) {
+      val actualBroker = new Broker()
+      actualBroker.fromJson(brokerJson)
+      BrokerTest.assertBrokerEquals(expectedBroker, actualBroker)
+    }
   }
 
   @Test

--- a/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
+++ b/src/test/ly/stealth/mesos/kafka/MesosTestCase.scala
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import ly.stealth.mesos.kafka.Cluster.FsStorage
 import org.I0Itec.zkclient.{ZkClient, IDefaultNameSpace, ZkServer}
 import java.net.ServerSocket
+import scala.concurrent.duration.Duration
 
 @Ignore
 class MesosTestCase {
@@ -456,6 +457,13 @@ class MesosTestCase {
 
     def sendFrameworkMessage(message: Array[Byte]): Status = throw new UnsupportedOperationException
   }
+
+  def delay(duration: String = "100ms")(f: => Unit) = new Thread {
+    override def run(): Unit = {
+      Thread.sleep(Duration(duration).toMillis)
+      f
+    }
+  }.start()
 }
 
 class TestBrokerServer extends BrokerServer {


### PR DESCRIPTION
MOTIVATION: 
Rolling restart manually:
1. stop one broker
2. update its configurations
3. start this one broker
4. repeat for next broker

Would be great to embed this steps into scheduler in single action.

PROPOSED CHANGE:

  CLI changes:

``````
add `broker restart <broker-expr>` command

command will send HTTP POST request to HTTP API, HTTP server will stop then start
each broker (one by one, sequentially, proceed to next only when previous restarted),
when timeout occurs process stops and returns JSON describing status "timeout" and
message "broker $id timeout on <stop|start>".

usage example:

  ./kafka-mesos.sh broker update 0..9 --options file:server.properties

  NOTE: allow ability to update running broker (currently only stopped broker can be udpated)

  ```
  ./kafka-mesos.sh broker restart 0..9 --timeout 2m

  restarted brokers:
    ...same output as for list of brokers
  ```

  timeout output will be:

  ```
  ./kafka-mesos.sh broker restart 0..9

  Error: broker 0 timeout on stop
  ```

help broker restart:

  ./kafka-mesos.sh help broker restart

  ```
  Start broker 
  Usage: broker start <broker-expr> [options]

  Option     Description                           
  ------     -----------                           
  --timeout  Time to wait until broker restarts. Defaults to 2m.

  ...
  ```

cli `broker list` affected by change, because in order to communicate back to user that broker
has been modified but not restarted flag needsRestart will be added to broker model whenever
broker is modified via `broker update` cmd flag will be set to `true` (default value is `false`),
once broker stopped (task update will be received in onTaskStopped) or right before launching task 
flag `modfied` will be set to `false`. Thus if broker has been udpated flag `needsRestart` will be set to
`true`, once `onTaskStopped` is called `needsRestart` will be set to `false`.

when broker `stopped`, flag `needsRestart` aren't shown to user

```
./kafka-mesos.sh broker list
brokers:

  id: 0
  active: false
  state: stopped (modified, needs restart)
``` 

when broker `running`, `starting`, `stopping`, `reconciling` 

```
./kafka-mesos.sh broker list
brokers:

  id: 0
  active: true
  state: running (modified, needs restart)
  ...
```

broker JSON representation changes: added `needsRestart` flag

```
{
  "id": "0",
  ...
  "needsRestart": true
}
```
``````

  HTTP API changes:

``````
add call for restart
POST /broker/restart
parameters:
  broker
  timeout

response format for success:
```
  {
    "status": "restarted",
    "brokers": [
      {
        "id": "0",
        ...
      }...
    ]
  }
```

response format for timeout:
```
  {
    "status": "timeout",
    "message": "broker $id timeout on [start|stop]"
  }
```
``````

  Scheduler changes: 

```
update attribute `needsRestart` set to `false` when 
- invoked `onTaskStopped`
- before task launch
```

RESULT: easy way to restart brokers (fixes #165)
