### PR TITLE
syslog

### DIFF
--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -44,6 +44,7 @@ class Broker(_id: String = "0") {
   var port: Range = null
   var volume: String = null
   var bindAddress: BindAddress = null
+  var syslog: Boolean = false
 
   var constraints: util.Map[String, Constraint] = new util.LinkedHashMap()
   var options: util.Map[String, String] = new util.LinkedHashMap()
@@ -254,6 +255,7 @@ class Broker(_id: String = "0") {
     if (node.contains("port")) port = new Range(node("port").asInstanceOf[String])
     if (node.contains("volume")) volume = node("volume").asInstanceOf[String]
     if (node.contains("bindAddress")) bindAddress = new BindAddress(node("bindAddress").asInstanceOf[String])
+    if (node.contains("syslog")) syslog = node("syslog").asInstanceOf[Boolean]
 
     if (node.contains("constraints")) constraints = Strings.parseMap(node("constraints").asInstanceOf[String])
                                                     .mapValues(new Constraint(_)).view.force
@@ -288,6 +290,7 @@ class Broker(_id: String = "0") {
     if (port != null) obj("port") = "" + port
     if (volume != null) obj("volume") = volume
     if (bindAddress != null) obj("bindAddress") = "" + bindAddress
+    obj("syslog") = syslog
 
     if (!constraints.isEmpty) obj("constraints") = Strings.formatMap(constraints)
     if (!options.isEmpty) obj("options") = Strings.formatMap(options)

--- a/src/scala/ly/stealth/mesos/kafka/BrokerServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/BrokerServer.scala
@@ -120,7 +120,7 @@ object BrokerServer {
 
     def configureLog4j(broker: Broker): Unit = {
       if (broker.syslog) {
-        val pattern = System.getenv("MESOS_SYSLOG_TAG") + ": %d [%t] %-5p %c %x - %m%n"
+        val pattern = System.getenv("MESOS_SYSLOG_TAG") + ": [%t] %-5p %c %x - %m%n"
 
         IO.replaceInFile(new File(Distro.dir + "/config/log4j.properties"), Map[String, String](
           "log4j.rootLogger=INFO, stdout" ->

--- a/src/scala/ly/stealth/mesos/kafka/Cli.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Cli.scala
@@ -466,6 +466,7 @@ object Cli {
       parser.accepts("port", "port or range (31092, 31090..31100). Default - auto").withRequiredArg().ofType(classOf[java.lang.String])
       parser.accepts("volume", "pre-reserved persistent volume id").withRequiredArg().ofType(classOf[java.lang.String])
       parser.accepts("bind-address", "broker bind address (broker0, 192.168.50.*, if:eth1). Default - auto").withRequiredArg().ofType(classOf[java.lang.String])
+      parser.accepts("syslog", "enable syslog logging. Default - false").withRequiredArg().ofType(classOf[java.lang.String])
       parser.accepts("stickiness-period", "stickiness period to preserve same node for broker (5m, 10m, 1h)").withRequiredArg().ofType(classOf[String])
 
       parser.accepts("options", "options or file. Examples:\n log.dirs=/tmp/kafka/$id,num.io.threads=16\n file:server.properties").withRequiredArg()
@@ -510,6 +511,7 @@ object Cli {
       val port = options.valueOf("port").asInstanceOf[String]
       val volume = options.valueOf("volume").asInstanceOf[String]
       val bindAddress = options.valueOf("bind-address").asInstanceOf[String]
+      val syslog = options.valueOf("syslog").asInstanceOf[String]
       val stickinessPeriod = options.valueOf("stickiness-period").asInstanceOf[String]
 
       val constraints = options.valueOf("constraints").asInstanceOf[String]
@@ -530,6 +532,7 @@ object Cli {
       if (port != null) params.put("port", port)
       if (volume != null) params.put("volume", volume)
       if (bindAddress != null) params.put("bindAddress", bindAddress)
+      if (syslog != null) params.put("syslog", syslog)
       if (stickinessPeriod != null) params.put("stickinessPeriod", stickinessPeriod)
 
       if (options_ != null) params.put("options", optionsOrFile(options_))
@@ -760,6 +763,7 @@ object Cli {
       printLine("resources: " + brokerResources(broker), indent)
 
       if (broker.bindAddress != null) printLine("bind-address: " + broker.bindAddress, indent)
+      if (broker.syslog) printLine("syslog: " + broker.syslog, indent)
       if (!broker.constraints.isEmpty) printLine("constraints: " + Strings.formatMap(broker.constraints), indent)
       if (!broker.options.isEmpty) printLine("options: " + Strings.formatMap(broker.options), indent)
       if (!broker.log4jOptions.isEmpty) printLine("log4j-options: " + Strings.formatMap(broker.log4jOptions), indent)

--- a/src/scala/ly/stealth/mesos/kafka/Executor.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Executor.scala
@@ -210,7 +210,7 @@ object Executor extends org.apache.mesos.Executor {
 
     if (System.getenv("MESOS_SYSLOG") != null) {
       val frameworkName = System.getenv("MESOS_SYSLOG_TAG")
-      val appender = new SyslogAppender(new PatternLayout(frameworkName + ": " + pattern), "localhost", SyslogAppender.LOG_USER)
+      val appender = new SyslogAppender(new PatternLayout(frameworkName + ": " + pattern.substring(3)), "localhost", SyslogAppender.LOG_USER)
 
       appender.setHeader(true)
       root.addAppender(appender)

--- a/src/scala/ly/stealth/mesos/kafka/Executor.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Executor.scala
@@ -209,7 +209,7 @@ object Executor extends org.apache.mesos.Executor {
     val pattern = "%d [%t] %-5p %c %x - %m%n"
 
     if (System.getenv("MESOS_SYSLOG") != null) {
-      val frameworkName = System.getenv("MESOS_FRAMEWORK_NAME")
+      val frameworkName = System.getenv("MESOS_SYSLOG_TAG")
       val appender = new SyslogAppender(new PatternLayout(frameworkName + ": " + pattern), "localhost", SyslogAppender.LOG_USER)
 
       appender.setHeader(true)

--- a/src/scala/ly/stealth/mesos/kafka/Executor.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Executor.scala
@@ -25,6 +25,7 @@ import org.apache.log4j._
 import java.util
 import com.google.protobuf.ByteString
 import scala.util.parsing.json.JSONObject
+import org.apache.log4j.net.SyslogAppender
 
 object Executor extends org.apache.mesos.Executor {
   val logger: Logger = Logger.getLogger(Executor.getClass)
@@ -205,8 +206,17 @@ object Executor extends org.apache.mesos.Executor {
     val logger = Logger.getLogger(Executor.getClass.getPackage.getName)
     logger.setLevel(if (System.getProperty("debug") != null) Level.DEBUG else Level.INFO)
 
-    val layout = new PatternLayout("%d [%t] %-5p %c %x - %m%n")
-    root.addAppender(new ConsoleAppender(layout))
+    val pattern = "%d [%t] %-5p %c %x - %m%n"
+
+    if (System.getenv("MESOS_SYSLOG") != null) {
+      val frameworkName = System.getenv("MESOS_FRAMEWORK_NAME")
+      val appender = new SyslogAppender(new PatternLayout(frameworkName + ": " + pattern), "localhost", SyslogAppender.LOG_USER)
+
+      appender.setHeader(true)
+      root.addAppender(appender)
+    }
+
+    root.addAppender(new ConsoleAppender(new PatternLayout(pattern)))
   }
 }
 

--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -209,6 +209,10 @@ object HttpServer {
         try { new BindAddress(request.getParameter("bindAddress")) }
         catch { case e: IllegalArgumentException => errors.add("Invalid bindAddress") }
 
+      var syslog: java.lang.Boolean = null
+      if (request.getParameter("syslog") != null)
+        syslog = java.lang.Boolean.valueOf(request.getParameter("syslog"))
+
       var stickinessPeriod: Period = null
       if (request.getParameter("stickinessPeriod") != null)
         try { stickinessPeriod = new Period(request.getParameter("stickinessPeriod")) }
@@ -277,6 +281,7 @@ object HttpServer {
         if (port != null) broker.port = if (port != "") new Range(port) else null
         if (volume != null) broker.volume = if (volume != "") volume else null
         if (bindAddress != null) broker.bindAddress = if (bindAddress != "") new BindAddress(bindAddress) else null
+        if (syslog != null) broker.syslog = syslog
         if (stickinessPeriod != null) broker.stickiness.period = stickinessPeriod
 
         if (constraints != null) broker.constraints = constraints

--- a/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
@@ -54,7 +54,7 @@ object Scheduler extends org.apache.mesos.Scheduler {
     }
 
     val env = new mutable.HashMap[String, String]()
-    env("MESOS_FRAMEWORK_NAME") = Config.frameworkName
+    env("MESOS_SYSLOG_TAG") = Config.frameworkName + "-" + broker.id
     if (broker.syslog) env("MESOS_SYSLOG") = "true"
 
     val envBuilder = Environment.newBuilder()

--- a/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
@@ -27,6 +27,8 @@ import java.util.{Collections, Date}
 import scala.collection.JavaConversions._
 import org.apache.log4j._
 import scala.Some
+import org.apache.mesos.Protos.Environment.Variable
+import scala.collection.mutable
 
 
 object Scheduler extends org.apache.mesos.Scheduler {
@@ -50,6 +52,15 @@ object Scheduler extends org.apache.mesos.Scheduler {
       commandBuilder.addUris(CommandInfo.URI.newBuilder().setValue(Config.api + "/jre/" + Config.jre.getName))
       cmd = "jre/bin/" + cmd
     }
+
+    val env = new mutable.HashMap[String, String]()
+    env("MESOS_FRAMEWORK_NAME") = Config.frameworkName
+    if (broker.syslog) env("MESOS_SYSLOG") = "true"
+
+    val envBuilder = Environment.newBuilder()
+    for ((name, value) <- env)
+      envBuilder.addVariables(Variable.newBuilder().setName(name).setValue(value))
+    commandBuilder.setEnvironment(envBuilder)
 
     commandBuilder
       .addUris(CommandInfo.URI.newBuilder().setValue(Config.api + "/jar/" + HttpServer.jar.getName).setExtract(false))

--- a/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
+++ b/src/test/ly/stealth/mesos/kafka/BrokerTest.scala
@@ -343,6 +343,7 @@ class BrokerTest extends KafkaMesosTestCase {
     broker.port = new Range("0..100")
     broker.volume = "volume"
     broker.bindAddress = new Util.BindAddress("192.168.0.1")
+    broker.syslog = true
 
     broker.constraints = parseMap("a=like:1").mapValues(new Constraint(_))
     broker.options = parseMap("a=1")
@@ -548,6 +549,7 @@ object BrokerTest {
     assertEquals(expected.port, actual.port)
     assertEquals(expected.volume, actual.volume)
     assertEquals(expected.bindAddress, actual.bindAddress)
+    assertEquals(expected.syslog, actual.syslog)
 
     assertEquals(expected.constraints, actual.constraints)
     assertEquals(expected.options, actual.options)


### PR DESCRIPTION
This PR adds Broker.syslog true|false option, that if enabled duplicates all log entries going from Executor and Kafka server into syslog.
