### PR TITLE
Change task and executor name to the framework name

### DIFF
--- a/src/scala/ly/stealth/mesos/kafka/Broker.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Broker.scala
@@ -305,14 +305,10 @@ class Broker(_id: String = "0") {
 }
 
 object Broker {
-  def nextTaskId(broker: Broker): String = "broker-" + broker.id + "-" + UUID.randomUUID()
-  def nextExecutorId(broker: Broker): String = "broker-" + broker.id + "-" + UUID.randomUUID()
+  def nextTaskId(broker: Broker): String = Config.frameworkName + "-" + broker.id + "-" + UUID.randomUUID()
+  def nextExecutorId(broker: Broker): String = Config.frameworkName + "-" + broker.id + "-" + UUID.randomUUID()
 
-  def idFromTaskId(taskId: String): String = {
-    val parts: Array[String] = taskId.split("-")
-    if (parts.length < 2) throw new IllegalArgumentException(taskId)
-    parts(1)
-  }
+  def idFromTaskId(taskId: String): String = taskId.dropRight(37).replace(Config.frameworkName + "-", "")
 
   def idFromExecutorId(executorId: String): String = idFromTaskId(executorId)
 

--- a/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
@@ -88,7 +88,7 @@ object Scheduler extends org.apache.mesos.Scheduler {
     }
 
     val taskBuilder: TaskInfo.Builder = TaskInfo.newBuilder
-      .setName("broker-" + broker.id)
+      .setName(Config.frameworkName + "-" + broker.id)
       .setTaskId(TaskID.newBuilder.setValue(Broker.nextTaskId(broker)).build)
       .setSlaveId(offer.getSlaveId)
       .setData(taskData)


### PR DESCRIPTION
I want to be able to run multiple kafka clusters on the same mesos while using mesos-dns / mesos-consul.

The dns names for the brokers is generated from the executor name, i.e. `broker-0.service.consul`. This means that I need different executor names for different clusters.

I was thinking about adding a task name or task prefix value but figured this solution was good since you want to know which task goes with which framework.

As you can see I swapped out the hard coded 'broker-' value. I also needed to change the logic of pulling the broker number out of this string since a framework name could include a dash.

Let me know if you have any questions or concerns.

This is almost exactly like the change in https://github.com/elodina/exhibitor-mesos-framework/pull/53 btw
