### PR TITLE
Added http endpoints for /qqq and /aaa

### DIFF
--- a/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
+++ b/src/scala/ly/stealth/mesos/kafka/HttpServer.scala
@@ -122,9 +122,11 @@ object HttpServer {
       if (uri.startsWith("/jar/")) downloadFile(HttpServer.jar, response)
       else if (uri.startsWith("/kafka/")) downloadFile(HttpServer.kafkaDist, response)
       else if (uri.startsWith("/jre/") && Config.jre != null) downloadFile(Config.jre, response)
-      else if (uri.startsWith("/health")) handleHealth(response)
       else if (uri.startsWith("/api/broker")) handleBrokerApi(request, response)
       else if (uri.startsWith("/api/topic")) handleTopicApi(request, response)
+      else if (uri.startsWith("/health")) handleHealth(response)
+      else if (uri.startsWith("/quitquitquit")) handleQuit(request, response)
+      else if (uri.startsWith("/abortabortabort")) handleAbort(request, response)
       else response.sendError(404, "uri not found")
     }
 
@@ -613,6 +615,20 @@ object HttpServer {
       result("state") = rebalancer.state
 
       response.getWriter.println(JSONObject(result.toMap))
+    }
+
+    def handleQuit(request: HttpServletRequest, response: HttpServletResponse): Unit = {
+      if (request.getMethod != "POST") {
+        response.sendError(405, "wrong method")
+      }
+      Scheduler.stop()
+    }
+
+    def handleAbort(request: HttpServletRequest, response: HttpServletResponse): Unit = {
+      if (request.getMethod != "POST") {
+        response.sendError(405, "wrong method")
+      }
+      Scheduler.kill()
     }
   }
 

--- a/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
+++ b/src/scala/ly/stealth/mesos/kafka/Scheduler.scala
@@ -408,6 +408,18 @@ object Scheduler extends org.apache.mesos.Scheduler {
     System.exit(status)
   }
 
+  def stop(): Unit = {
+    if (driver != null) {
+      // Warning: stop(false) and stop() are dangerous, calling them will destroy the framework
+      // and kill all running tasks / executors.
+      driver.stop(true)
+    }
+  }
+
+  def kill(): Unit = {
+    System.exit(1)
+  }
+
   private def initLogging() {
     HttpServer.initLogging()
     BasicConfigurator.resetConfiguration()


### PR DESCRIPTION
The context behind this is to allow clean shutdown of the scheduler when running from Aurora.

Responding to /quitquitquit and /abortabortabort allows the scheduler to cleanly shutdown when requested.
