### PR TITLE
Call JVM through exec in kafka-mesos.sh

### DIFF
--- a/kafka-mesos.sh
+++ b/kafka-mesos.sh
@@ -16,4 +16,4 @@ check_jar() {
 }
 
 check_jar
-java -jar $jar "$@"
+exec java -jar $jar "$@"


### PR DESCRIPTION
Call JVM through exec so signals are correctly handled when running in a Docker container.
