### PR TITLE
Fixed curl's http method written in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The scheduler is configured through the command line or `kafka-mesos.properties`
 The following options are available:
 ```
 # ./kafka-mesos.sh help scheduler
-Start scheduler 
+Start scheduler
 Usage: scheduler [options] [config.properties]
 
 Option               Description
@@ -310,7 +310,7 @@ current limit is 100Kb no matter how many lines being requested.
 
 High Availability Scheduler State
 -------------------------
-The scheduler supports storing the cluster state in Zookeeper. It currently shares a znode within the mesos ensemble. To turn this on in properties 
+The scheduler supports storing the cluster state in Zookeeper. It currently shares a znode within the mesos ensemble. To turn this on in properties
 
 ```
 clusterStorage=zk:/kafka-mesos
@@ -889,12 +889,12 @@ Listing topic partition details
  Picked up _JAVA_OPTIONS: -Djava.net.preferIPv4Stack=true
  List partitions
  Usage: topic partition [<topic>]
- 
+
  Generic Options
  Option  Description
  ------  -----------
  --api   Api url. Example: http://master:7000
- 
+
  topic-expr examples:
    t0        - topic t0
    t0,t1     - topics t0, t1
@@ -995,34 +995,34 @@ Listing brokers
 Adding a broker
 
 ```
-# curl "http://localhost:7000/api/broker/add?broker=0&cpus=8&mem=43008"
+# curl -X POST "http://localhost:7000/api/broker/add?broker=0&cpus=8&mem=43008"
 {"brokers" : [{"id" : "0", "mem" : 43008, "cpus" : 8.0, "heap" : 128, "failover" : {"delay" : "10s", "maxDelay" : "60s"}, "active" : false}]}
 ```
 
 Starting a broker
 
 ```
-# curl "http://localhost:7000/api/broker/start?broker=0"
+# curl -X POST "http://localhost:7000/api/broker/start?broker=0"
 {"success" : true, "ids" : "0"}
 ```
 
 Stopping a broker
 
 ```
-# curl "http://localhost:7000/api/broker/stop?broker=0"
+# curl -X POST "http://localhost:7000/api/broker/stop?broker=0"
 {"success" : true, "ids" : "0"}
 ```
 
 Restarting a broker
 
 ```
-# curl "http://localhost:7000/api/broker/restart?broker=0"
+# curl -X POST "http://localhost:7000/api/broker/restart?broker=0"
 {"status" : "restarted", "brokers" : [{"task" : {"hostname" : "slave0", "state" : "running", "slaveId" : "fd935975-5db0-4732-bfa4-3063b534972d-S3", "executorId" : "broker-0-a8e0d084-b890-4482-800e-12e72ed7f9ed", "attributes" : {}, "id" : "broker-0-ff11db36-206a-4019-9cd2-6993376831eb", "endpoint" : "slave0:9092"}, "stickiness" : {"period" : "10m", "hostname" : "slave0"}, "bindAddress" : "slave0", "options" : "log.dirs=\/tmp\/kafka\/$id", "id" : "2", "port" : "9092", "constraints" : "hostname=like:slave0", "mem" : 1024, "cpus" : 0.5, "metrics" : {"underReplicatedPartitions" : 0, "offlinePartitionsCount" : 0, "activeControllerCount" : 0, "timestamp" : 1455557472857}, "heap" : 1024, "failover" : {"delay" : "1m", "maxDelay" : "14m"}, "active" : true}]}
 ```
 Removing a broker
 
 ```
-# curl "http://localhost:7000/api/broker/remove?broker=0"
+# curl -X POST "http://localhost:7000/api/broker/remove?broker=0"
 {"ids" : "0"}
 ```
 
@@ -1034,13 +1034,13 @@ Listing topics
 
 Adding topic
 ```
-# curl "http://localhost:7000/api/topic/add?topic=t"
+# curl -X POST "http://localhost:7000/api/topic/add?topic=t"
 {"topic" : {"name" : "t", "partitions" : {"0" : "1"}, "options" : {}}}
 ```
 
 Updating topic
 ```
-# curl "http://localhost:7000/api/topic/update?topic=t&options=flush.ms%3D1000"
+# curl -X POST "http://localhost:7000/api/topic/update?topic=t&options=flush.ms%3D1000"
 {"topic" : {"name" : "t", "partitions" : {"0" : "0, 1"}, "options" : {"flush.ms" : "1000"}}}
 ```
 
@@ -1055,4 +1055,4 @@ Project Goals
 
 * scaling the cluster up and down with automatic, programmatic and manual options.
 
-* smart partition assignment via constraints, roles, resources and attributes. 
+* smart partition assignment via constraints, roles, resources and attributes.


### PR DESCRIPTION
Methods that mutate state (restart, add, delete broker, etc) with the new version(0.10.0.0) are no longer accepting GET requests, but changed to accept only POST. 
(See also: https://github.com/mesos/kafka/releases/tag/v0.10.0.0)

So, I fixed the curl's HTTP method written in the README.md.

Please confirm this PR.
Thank you