### PR TITLE
Changed kafka version in README to reflect working version (2.11-0.8.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Clone and build the project
     # git clone https://github.com/mesos/kafka
     # cd kafka
     # ./gradlew jar
-    # wget https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.10-0.8.2.2.tgz
+    # wget https://archive.apache.org/dist/kafka/0.8.2.2/kafka_2.11-0.8.2.2.tgz
 
 Environment Configuration
 --------------------------


### PR DESCRIPTION
With version from old instructions broker will not start with error:
```
reason:REASON_COMMAND_EXECUTOR_FAILED message:java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at ly.stealth.mesos.kafka.executor.MetricCollectorProxy.ly$stealth$mesos$kafka$executor$MetricCollectorProxy$$collect(MetricCollectorProxy.scala:49)
	at ly.stealth.mesos.kafka.executor.MetricCollectorProxy.start(MetricCollectorProxy.scala:45)
	at ly.stealth.mesos.kafka.executor.KafkaServer$Distro$.startCollector(BrokerServer.scala:201)
	at ly.stealth.mesos.kafka.executor.KafkaServer.start(BrokerServer.scala:90)
	at ly.stealth.mesos.kafka.executor.Executor$$anon$1.run(Executor.scala:94)
Caused by: java.lang.NoSuchMethodError: scala.Predef$.ArrowAssoc(Ljava/lang/Object;)Ljava/lang/Object;
	at ly.stealth.mesos.kafka.executor.MetricCollectorProxy$MetricsCollector.collectJvmMetrics(MetricCollectorProxy.scala:111)
	at ly.stealth.mesos.kafka.executor.MetricCollectorProxy$MetricsCollector.run(MetricCollectorProxy.scala:194)
	... 9 more
```
