### PR TITLE
Version up mesos to 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 def scalaVersion = "2.11.8"
-def mesosVersion = "0.28.0"
+def mesosVersion = "1.3.0"
 ext.kafkaVersion = project.hasProperty("kafkaVersion") ? project.getProperty("kafkaVersion") : "0.10.2.0"
 def kafkaMajorVersion="${kafkaVersion.split("\\.").take(2).join("_")}"
 def kafkaScalaVersion=scalaVersion.split("\\.").take(2).join(".")

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 def scalaVersion = "2.11.8"
-def mesosVersion = "1.3.0"
+def mesosVersion = project.hasProperty("mesosVersion") ? project.getProperty("mesosVersion") :"1.3.0"
 ext.kafkaVersion = project.hasProperty("kafkaVersion") ? project.getProperty("kafkaVersion") : "0.10.2.0"
 def kafkaMajorVersion="${kafkaVersion.split("\\.").take(2).join("_")}"
 def kafkaScalaVersion=scalaVersion.split("\\.").take(2).join(".")


### PR DESCRIPTION
Hi, I used mesos-kafka in mesos version 1.3.0.
However, it was not started up because it was built mesos version 0.28.0.
So, I update mesos version to 1.3.0. 

I checked running in mesos version 1.3.0.

Please this pull request.
Thanks