### PR TITLE
Fixes Issue : 316 :: https://github.com/mesos/kafka/issues/316

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 out/*
 project/*
 .gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@
 
 language: java
 sudo: false
-
+dist: precise
 jdk:
   - oraclejdk8
   - oraclejdk7

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'scala'
     id 'idea'
     id 'distribution'
-    id 'de.undercouch.download' version '2.1.0'
+    id 'de.undercouch.download' version '3.2.0'
     id "com.github.hierynomus.license" version "0.13.1"
 }
 
@@ -93,20 +93,20 @@ dependencies {
 jar {
     dependsOn 'test'
 
-    doFirst {
-        from(configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }) {
-            exclude "*"
-            exclude "about_files/*"
-            exclude "META-INF/*.SF"
-            exclude "META-INF/*.DSA"
-            exclude "META-INF/*.RSA"
-        }
+    
+    from(configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }) {
+        exclude "*"
+        exclude "about_files/*"
+        exclude "META-INF/*.SF"
+        exclude "META-INF/*.DSA"
+        exclude "META-INF/*.RSA"
     }
+    
     manifest.attributes("Main-Class": "ly.stealth.mesos.kafka.cli.Cli")
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.8'
+    gradleVersion = '4.1'
 }
 
 distributions.main {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip


### PR DESCRIPTION
updated gradle build to 4.1
updated de.undercouch.download to version 3.2.0 and made changes in jar task respectively
added dist as precise in .travis.yaml as going forward travis is using trusty as the default run environment.