### PR TITLE
Fix #317 - upgrade Kafka to 0.11.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,14 @@ jdk:
   - oraclejdk8
   - oraclejdk7
 env:
+  - KAFKA_VER=0.11.0.0
   - KAFKA_VER=0.10.2.0
   - KAFKA_VER=0.9.0.1
   - KAFKA_VER=0.8.2.2
 matrix:
   exclude:
+  - jdk: oraclejdk7
+    env: KAFKA_VER=0.11.0.0
   - jdk: oraclejdk7
     env: KAFKA_VER=0.9.0.1
   - jdk: oraclejdk7

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 def scalaVersion = "2.11.8"
 def mesosVersion = "0.28.0"
-ext.kafkaVersion = project.hasProperty("kafkaVersion") ? project.getProperty("kafkaVersion") : "0.10.2.0"
+ext.kafkaVersion = project.hasProperty("kafkaVersion") ? project.getProperty("kafkaVersion") : "0.11.0.0"
 def kafkaMajorVersion="${kafkaVersion.split("\\.").take(2).join("_")}"
 def kafkaScalaVersion=scalaVersion.split("\\.").take(2).join(".")
 def jettyVersion = "9.0.4.v20130625"

--- a/src/scala/iface/0_11/ly/stealth/mesos/kafka/interface/impl/AdminUtils.scala
+++ b/src/scala/iface/0_11/ly/stealth/mesos/kafka/interface/impl/AdminUtils.scala
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ly.stealth.mesos.kafka.interface.impl
+
+import kafka.utils.{ZkUtils => KafkaZkUtils}
+import kafka.admin.{BrokerMetadata, AdminUtils => KafkaAdminUtils}
+import java.util.Properties
+import ly.stealth.mesos.kafka.interface.{AdminUtilsProxy, FeatureSupport}
+import scala.collection.Map
+
+
+class AdminUtils(zkUrl: String) extends AdminUtilsProxy {
+  private val DEFAULT_TIMEOUT_MS = 30000
+  private val zkUtils = KafkaZkUtils(zkUrl, DEFAULT_TIMEOUT_MS, DEFAULT_TIMEOUT_MS, isZkSecurityEnabled = false)
+
+  override def fetchAllTopicConfigs(): Map[String, Properties] = KafkaAdminUtils.fetchAllTopicConfigs(zkUtils)
+
+  override def createOrUpdateTopicPartitionAssignmentPathInZK(
+    topic: String,
+    partitionReplicaAssignment: Map[Int, Seq[Int]],
+    config: Properties,
+    update: Boolean
+  ): Unit = KafkaAdminUtils.createOrUpdateTopicPartitionAssignmentPathInZK(zkUtils, topic, partitionReplicaAssignment, config, update)
+
+  override def changeTopicConfig(
+    topic: String,
+    configs: Properties
+  ): Unit = KafkaAdminUtils.changeTopicConfig(zkUtils, topic, configs)
+
+  override def deleteTopic(topicToDelete: String): Unit =
+    KafkaAdminUtils.deleteTopic(zkUtils, topicToDelete)
+
+  override def fetchEntityConfig(
+    entityType: String,
+    entity: String
+  ): Properties = KafkaAdminUtils.fetchEntityConfig(zkUtils, entityType, entity)
+
+  override def changeClientIdConfig(
+    clientId: String,
+    configs: Properties
+  ): Unit = KafkaAdminUtils.changeClientIdConfig(zkUtils, clientId, configs)
+
+  override def fetchAllEntityConfigs(entityType: String): Map[String, Properties]
+  = KafkaAdminUtils.fetchAllEntityConfigs(zkUtils, entityType)
+
+  override def assignReplicasToBrokers(
+    ids: Seq[Int],
+    nPartitions: Int,
+    replicationFactor: Int,
+    fixedStartIndex: Int,
+    startPartitionId: Int
+  ): Map[Int, Seq[Int]] = {
+    val md = ids.map(BrokerMetadata(_, None))
+    KafkaAdminUtils.assignReplicasToBrokers(md, nPartitions, replicationFactor, fixedStartIndex, startPartitionId)
+  }
+
+  override val features: FeatureSupport = FeatureSupport(quotas = true, genericEntityConfigs = true)
+}

--- a/src/scala/iface/0_11/ly/stealth/mesos/kafka/interface/impl/ZkUtils.scala
+++ b/src/scala/iface/0_11/ly/stealth/mesos/kafka/interface/impl/ZkUtils.scala
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ly.stealth.mesos.kafka.interface.impl
+
+import kafka.utils.{ZkUtils => KafkaZkUtils}
+import kafka.common.TopicAndPartition
+import kafka.controller.{LeaderIsrAndControllerEpoch, ReassignedPartitionsContext}
+import ly.stealth.mesos.kafka.interface.ZkUtilsProxy
+import scala.collection.{Map, Set, mutable}
+
+class ZkUtils(zkUrl: String) extends ZkUtilsProxy {
+  private val DEFAULT_TIMEOUT_MS = 30000
+  private val zkUtils = KafkaZkUtils(zkUrl, DEFAULT_TIMEOUT_MS, DEFAULT_TIMEOUT_MS, isZkSecurityEnabled = false)
+
+  override def getAllTopics(): Seq[String] = zkUtils.getAllTopics()
+
+  override def getReplicaAssignmentForTopics(topics: Seq[String]): mutable.Map[TopicAndPartition, Seq[Int]]
+    = zkUtils.getReplicaAssignmentForTopics(topics)
+
+  override def getPartitionsBeingReassigned(): Map[TopicAndPartition, ReassignedPartitionsContext]
+    = zkUtils.getPartitionsBeingReassigned()
+
+  override def getReplicasForPartition(
+    topic: String,
+    partition: Int
+  ): Seq[Int] = zkUtils.getReplicasForPartition(topic, partition)
+
+  override def updatePartitionReassignmentData(partitionsToBeReassigned: Map[TopicAndPartition, Seq[Int]]): Unit
+    = zkUtils.updatePartitionReassignmentData(partitionsToBeReassigned)
+
+  override def createPersistentPath(
+    path: String,
+    data: String
+  ): Unit = zkUtils.createPersistentPath(path, data)
+
+  override def getPartitionAssignmentForTopics(topics: Seq[String]): mutable.Map[String, Map[Int, Seq[Int]]]
+    = zkUtils.getPartitionAssignmentForTopics(topics)
+
+  override def getPartitionLeaderAndIsrForTopics(topicAndPartitions: Set[TopicAndPartition]): mutable.Map[TopicAndPartition, LeaderIsrAndControllerEpoch]
+    = zkUtils.getPartitionLeaderAndIsrForTopics(topicAndPartitions)
+
+  override def getSortedBrokerList(): Seq[Int] = zkUtils.getSortedBrokerList()
+}


### PR DESCRIPTION
I had to change line 54 in ZkUtils from `zkUtils.getPartitionLeaderAndIsrForTopics(null, topicAndPartitions)` to `zkUtils.getPartitionLeaderAndIsrForTopics(topicAndPartitions)`. It was complaining about too many arguments.

I was trying to use minimesos and was able to register the framework, but I was not able to add a broker (the `broker add 0` command would just sit doing nothing), however, this doesn't appear to be related to 0.11.0.0, as I couldn't do it with 0.10.2.0 either (I need a better place to test with mesos).